### PR TITLE
Add OneANotation for number-first BB26 values

### DIFF
--- a/TIKSN.Framework.Core.Tests/Numbering/OneANotationTests.cs
+++ b/TIKSN.Framework.Core.Tests/Numbering/OneANotationTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Shouldly;
+using TIKSN.Numbering;
+using Xunit;
+
+namespace TIKSN.Tests.Numbering;
+
+public class OneANotationTests
+{
+    public static IEnumerable<TheoryDataRow<string, int, string>> GetParseTestData()
+    {
+        yield return new TheoryDataRow<string, int, string>("1A", p2: 1, "A");
+        yield return new TheoryDataRow<string, int, string>("1a", p2: 1, "A");
+        yield return new TheoryDataRow<string, int, string>("1-A", p2: 1, "A");
+        yield return new TheoryDataRow<string, int, string>("1-a", p2: 1, "A");
+        yield return new TheoryDataRow<string, int, string>("2B", p2: 2, "B");
+        yield return new TheoryDataRow<string, int, string>("10C", p2: 10, "C");
+        yield return new TheoryDataRow<string, int, string>("10AA", p2: 10, "AA");
+        yield return new TheoryDataRow<string, int, string>("65535ZZ", p2: 65535, "ZZ");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("A1")]
+    [InlineData("A-1")]
+    [InlineData("1")]
+    [InlineData("A")]
+    [InlineData("0A")]
+    [InlineData("0-A")]
+    [InlineData("65536A")]
+    public void GivenInvalidString_WhenParse_ThenResultShouldBeNone(string input)
+    {
+        var result = OneANotation<ushort>.Parse(input, asciiOnly: false, CultureInfo.InvariantCulture);
+
+        result.IsNone.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenConstructedWithNullSerial_ThenThrowsArgumentNullException() =>
+        Should.Throw<ArgumentNullException>(() => new OneANotation<ushort>(number: 1, serial: null));
+
+    [Fact]
+    public void GivenOneANotation_WhenConstructedWithValidParameters_ThenPropertiesSet()
+    {
+        var serial = new BB26(1);
+        var number = ushort.MaxValue;
+
+        var oneANotation = new OneANotation<ushort>(number, serial);
+
+        oneANotation.Serial.ShouldBe(serial);
+        oneANotation.Number.ShouldBe(number);
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenConstructedWithZeroNumber_ThenThrowsArgumentException() =>
+        Should.Throw<ArgumentException>(() => new OneANotation<ushort>(number: default, new BB26(1)));
+
+    [Fact]
+    public void GivenOneANotation_WhenGetHashCode_ThenConsistent()
+    {
+        var oneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+        var anotherOneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        oneA.GetHashCode().ShouldBe(anotherOneA.GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("1A", "2A", null)]
+    [InlineData("65535A", null, "65534A")]
+    [InlineData("1Z", "2Z", null)]
+    [InlineData("65535Z", null, "65534Z")]
+    [InlineData("1AA", "2AA", null)]
+    [InlineData("65535AA", null, "65534AA")]
+    public void GivenOneANotation_WhenGetNextAndPrevious_ThenResultShouldBe(
+        string input, string? expectedNext, string? expectedPrevious)
+    {
+        var oneANotation = OneANotation<ushort>.Parse(input, asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var next = oneANotation.GetNext();
+        var previous = oneANotation.GetPrevious();
+
+        var nextValue = next.Map(x => x.ToString()).MatchUnsafe(x => x, () => null);
+        var previousValue = previous.Map(x => x.ToString()).MatchUnsafe(x => x, () => null);
+
+        nextValue.ShouldBe(expectedNext);
+        previousValue.ShouldBe(expectedPrevious);
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenNullEquals_ThenFalse()
+    {
+        var oneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        oneA.Equals(null).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(null, "1A")]
+    [InlineData("", "1A")]
+    [InlineData("G", "1A")]
+    [InlineData("N", "1A")]
+    [InlineData("H", "1-A")]
+    public void GivenOneANotation_WhenToStringWithFormat_ThenResultShouldBe(string? format, string expected)
+    {
+        var oneANotation = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var result = oneANotation.ToString(format, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("1A", "1A")]
+    [InlineData("2B", "2B")]
+    [InlineData("10AA", "10AA")]
+    [InlineData("65535ZZ", "65535ZZ")]
+    public void GivenOneANotation_WhenToString_ThenResultShouldBe(string expected, string input)
+    {
+        var oneANotation = OneANotation<ushort>.Parse(input, asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var result = oneANotation.ToString();
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenTryFormatWithHyphenFormat_ThenSuccess()
+    {
+        var oneANotation = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var buffer = new char[10];
+        var success = oneANotation.TryFormat(buffer, out var charsWritten, "H", CultureInfo.InvariantCulture);
+
+        success.ShouldBeTrue();
+        charsWritten.ShouldBe(3);
+        new string(buffer, startIndex: 0, charsWritten).ShouldBe("1-A");
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenTryFormatWithInsufficientBuffer_ThenFailure()
+    {
+        var oneANotation = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var buffer = new char[1];
+        var success = oneANotation.TryFormat(buffer, out var charsWritten, format: null, CultureInfo.InvariantCulture);
+
+        success.ShouldBeFalse();
+        charsWritten.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GivenOneANotation_WhenTryFormatWithSufficientBuffer_ThenSuccess()
+    {
+        var oneANotation = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        var buffer = new char[10];
+        var success = oneANotation.TryFormat(buffer, out var charsWritten, format: null, CultureInfo.InvariantCulture);
+
+        success.ShouldBeTrue();
+        charsWritten.ShouldBe(2);
+        new string(buffer, startIndex: 0, charsWritten).ShouldBe("1A");
+    }
+
+    [Theory]
+    [InlineData("1A", true)]
+    [InlineData("1-A", true)]
+    [InlineData("2B", true)]
+    [InlineData("65535ZZ", true)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("A", false)]
+    [InlineData("0A", false)]
+    public void GivenString_WhenTryParse_ThenResultShouldBe(string input, bool expectedSuccess)
+    {
+        var success = OneANotation<ushort>.TryParse(input, CultureInfo.InvariantCulture, out var result);
+
+        success.ShouldBe(expectedSuccess);
+        if (expectedSuccess)
+        {
+            _ = result.ShouldNotBeNull();
+        }
+        else
+        {
+            result.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void GivenTwoDifferentOneANotations_WhenEquals_ThenFalse()
+    {
+        var oneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+        var twoA = OneANotation<ushort>.Parse("2A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        oneA.Equals(twoA).ShouldBeFalse();
+        (oneA == twoA).ShouldBeFalse();
+        (oneA != twoA).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenTwoEqualOneANotations_WhenEquals_ThenTrue()
+    {
+        var oneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+        var anotherOneA = OneANotation<ushort>.Parse("1A", asciiOnly: false, CultureInfo.InvariantCulture)
+            .Match(x => x, () => throw new InvalidOperationException());
+
+        oneA.Equals(anotherOneA).ShouldBeTrue();
+        (oneA == anotherOneA).ShouldBeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(GetParseTestData))]
+    public void GivenValidString_WhenParse_ThenResultShouldBe(string input, int expectedNumber, string expectedSerial)
+    {
+        var result = OneANotation<ushort>.Parse(input, asciiOnly: false, CultureInfo.InvariantCulture);
+
+        result.IsSome.ShouldBeTrue();
+        var oneANotation = result.Match(x => x, () => throw new InvalidOperationException());
+        oneANotation.Number.ShouldBe((ushort)expectedNumber);
+        oneANotation.Serial.ToString().ShouldBe(expectedSerial);
+    }
+}

--- a/TIKSN.Framework.Core/Numbering/NumberFirstSerialNumber.cs
+++ b/TIKSN.Framework.Core/Numbering/NumberFirstSerialNumber.cs
@@ -1,0 +1,203 @@
+using System.Globalization;
+using System.Numerics;
+using LanguageExt;
+using static LanguageExt.Parsec.Char;
+using static LanguageExt.Parsec.Prim;
+using static LanguageExt.Prelude;
+
+namespace TIKSN.Numbering;
+
+#pragma warning disable CA1000 // Do not declare static members on generic types
+public sealed class NumberFirstSerialNumber<TNumber, TSerial> :
+    ISerialNumber<NumberFirstSerialNumber<TNumber, TSerial>>
+    where TNumber : IUnsignedNumber<TNumber>
+    where TSerial : ISerial<TSerial>
+{
+    public NumberFirstSerialNumber(TNumber number, TSerial serial)
+    {
+        this.Number = number ?? throw new ArgumentNullException(nameof(number));
+        this.Serial = serial ?? throw new ArgumentNullException(nameof(serial));
+    }
+
+    public TNumber Number { get; }
+
+    public TSerial Serial { get; }
+
+    public static NumberFirstSerialNumber<TNumber, TSerial> Parse(string s, IFormatProvider? provider)
+    {
+        if (TryParse(s, provider, out var result))
+        {
+            return result;
+        }
+
+        throw new FormatException("Input string was not in a correct format.");
+    }
+
+    public static NumberFirstSerialNumber<TNumber, TSerial> Parse(
+        ReadOnlySpan<char> s,
+        IFormatProvider? provider)
+        => Parse(s.ToString(), provider);
+
+    public static Option<NumberFirstSerialNumber<TNumber, TSerial>> Parse(
+        string s,
+        bool asciiOnly,
+        IFormatProvider? provider)
+    {
+        if (string.IsNullOrEmpty(s))
+        {
+            return None;
+        }
+
+        Option<TNumber> parseNumber(string value)
+        {
+            if (TNumber.TryParse(value, provider, out var num))
+            {
+                return Some(num);
+            }
+
+            return None;
+        }
+
+        var numberParser =
+            from xs in many(digit)
+            let r = new string([.. xs])
+            let val = parseNumber(r)
+            from res in val.Match(
+                Some: result<TNumber>,
+                None: failure<TNumber>("Failed to parse a number'"))
+            select res;
+
+        var serialParser =
+            from xs in many(letter)
+            let r = new string([.. xs])
+            let val = TSerial.Parse(r, asciiOnly, provider)
+            from res in val.Match(
+                Some: result<TSerial>,
+                None: failure<TSerial>("Failed to parse a serial'"))
+            select res;
+
+        var parser =
+            from number in numberParser
+            from _1 in optional(ch('-'))
+            from serial in serialParser
+            from _2 in eof
+            select new NumberFirstSerialNumber<TNumber, TSerial>(number, serial);
+
+        var result = parse(parser, s);
+
+        return result.ToOption();
+    }
+
+    public static Option<NumberFirstSerialNumber<TNumber, TSerial>> Parse(
+        ReadOnlySpan<char> s,
+        bool asciiOnly,
+        IFormatProvider? provider)
+        => Parse(s.ToString(), asciiOnly, provider);
+
+    public static bool TryParse(
+        string? s,
+        IFormatProvider? provider,
+        out NumberFirstSerialNumber<TNumber, TSerial> result)
+    {
+        if (s is null)
+        {
+            result = default!;
+            return false;
+        }
+
+        var serialNumber = Parse(s, asciiOnly: false, provider);
+        result = serialNumber.MatchUnsafe(x => x, () => default)!;
+        return serialNumber.IsSome;
+    }
+
+    public static bool TryParse(
+        ReadOnlySpan<char> s,
+        IFormatProvider? provider,
+        out NumberFirstSerialNumber<TNumber, TSerial> result)
+        => TryParse(s.ToString(), provider, out result);
+
+    public static bool operator ==(
+        NumberFirstSerialNumber<TNumber, TSerial> left,
+        NumberFirstSerialNumber<TNumber, TSerial> right) => Equals(left, right);
+
+    public static bool operator !=(
+        NumberFirstSerialNumber<TNumber, TSerial> left,
+        NumberFirstSerialNumber<TNumber, TSerial> right) => !Equals(left, right);
+
+    public bool Equals(NumberFirstSerialNumber<TNumber, TSerial>? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return EqualityComparer<TNumber>.Default.Equals(this.Number, other.Number) &&
+            EqualityComparer<TSerial>.Default.Equals(this.Serial, other.Serial);
+    }
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj) ||
+            (obj is NumberFirstSerialNumber<TNumber, TSerial> other && this.Equals(other));
+
+    public override int GetHashCode() => HashCode.Combine(this.Number, this.Serial);
+
+    public Option<NumberFirstSerialNumber<TNumber, TSerial>> GetNext()
+    {
+        var nextNumber = this.Number + TNumber.One;
+        if (TNumber.IsZero(nextNumber))
+        {
+            return None;
+        }
+
+        return new NumberFirstSerialNumber<TNumber, TSerial>(nextNumber, this.Serial);
+    }
+
+    public Option<NumberFirstSerialNumber<TNumber, TSerial>> GetPrevious()
+    {
+        if (TNumber.IsZero(this.Number))
+        {
+            return None;
+        }
+
+        return new NumberFirstSerialNumber<TNumber, TSerial>(this.Number - TNumber.One, this.Serial);
+    }
+
+    public override string ToString()
+        => this.ToString(format: null, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Formats the serial number using the specified format.
+    /// </summary>
+    /// <param name="format">Format specifier: null, empty, "G", or "N" for "NumberSerial" (no hyphen); "H" for "Number-Serial" (with hyphen).</param>
+    /// <param name="formatProvider">Format provider.</param>
+    /// <returns>Formatted serial number string.</returns>
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        var numberString = this.Number.ToString(format: null, formatProvider);
+        var serialString = this.Serial.ToString(format: null, formatProvider);
+
+        return format switch
+        {
+            "H" => $"{numberString}-{serialString}",
+            _ => numberString + serialString,
+        };
+    }
+
+    public bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        var result = this.ToString(new string(format), provider);
+        charsWritten = Math.Min(result.Length, destination.Length);
+        result[..charsWritten].CopyTo(destination);
+        return charsWritten == result.Length;
+    }
+}
+#pragma warning restore CA1000 // Do not declare static members on generic types

--- a/TIKSN.Framework.Core/Numbering/OneANotation.cs
+++ b/TIKSN.Framework.Core/Numbering/OneANotation.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using LanguageExt;
+using static LanguageExt.Prelude;
+
+namespace TIKSN.Numbering;
+
+public sealed class OneANotation<TNumber> : ISerialNumber<OneANotation<TNumber>>
+    where TNumber : IUnsignedNumber<TNumber>
+{
+    private readonly NumberFirstSerialNumber<TNumber, BB26> serialNumber;
+
+    public OneANotation(NumberFirstSerialNumber<TNumber, BB26> serialNumber)
+    {
+        this.serialNumber = serialNumber ?? throw new ArgumentNullException(nameof(serialNumber));
+        if (Validate(this.serialNumber).IsNone)
+        {
+            throw new ArgumentException("Number cannot be zero.", nameof(serialNumber));
+        }
+    }
+
+    public OneANotation(TNumber number, BB26 serial) : this(new NumberFirstSerialNumber<TNumber, BB26>(number, serial))
+    {
+    }
+
+    public TNumber Number => this.serialNumber.Number;
+
+    public BB26 Serial => this.serialNumber.Serial;
+
+    public static Option<OneANotation<TNumber>> Parse(string s, bool asciiOnly, IFormatProvider? provider) =>
+        Validate(NumberFirstSerialNumber<TNumber, BB26>.Parse(s, asciiOnly, provider))
+            .Map(x => new OneANotation<TNumber>(x));
+
+    public static Option<OneANotation<TNumber>>
+        Parse(ReadOnlySpan<char> s, bool asciiOnly, IFormatProvider? provider) =>
+        Validate(NumberFirstSerialNumber<TNumber, BB26>.Parse(s, asciiOnly, provider))
+            .Map(x => new OneANotation<TNumber>(x));
+
+    public static OneANotation<TNumber> Parse(
+        ReadOnlySpan<char> s,
+        IFormatProvider? provider) =>
+        new(NumberFirstSerialNumber<TNumber, BB26>.Parse(s, provider));
+
+    public static OneANotation<TNumber> Parse(string s, IFormatProvider? provider) =>
+        new(NumberFirstSerialNumber<TNumber, BB26>.Parse(s, provider));
+
+    public static bool TryParse(
+        ReadOnlySpan<char> s,
+        IFormatProvider? provider,
+        [MaybeNullWhen(false)] out OneANotation<TNumber> result)
+        => TryParse(s.ToString(), provider, out result);
+
+    public static bool TryParse(
+        [NotNullWhen(true)] string? s,
+        IFormatProvider? provider,
+        [MaybeNullWhen(false)] out OneANotation<TNumber> result)
+    {
+        if (s is null)
+        {
+            result = default;
+            return false;
+        }
+
+        var serialNumber = Parse(s, asciiOnly: false, provider);
+        result = serialNumber.MatchUnsafe(x => x, () => default)!;
+
+        return serialNumber.IsSome;
+    }
+
+    public static bool operator ==(OneANotation<TNumber> left, OneANotation<TNumber> right) => Equals(left, right);
+
+    public static bool operator !=(OneANotation<TNumber> left, OneANotation<TNumber> right) => !Equals(left, right);
+
+    public bool Equals(OneANotation<TNumber>? other) => this.serialNumber.Equals(other?.serialNumber);
+
+    public override bool Equals(object? obj) => this.Equals(obj as OneANotation<TNumber>);
+
+    public override int GetHashCode() => this.serialNumber.GetHashCode();
+
+    public Option<OneANotation<TNumber>> GetNext() =>
+        this.serialNumber.GetNext().Map(x => new OneANotation<TNumber>(x));
+
+    public Option<OneANotation<TNumber>> GetPrevious() =>
+        Validate(this.serialNumber.GetPrevious()).Map(x => new OneANotation<TNumber>(x));
+
+    public string ToString(string? format, IFormatProvider? formatProvider) =>
+        this.serialNumber.ToString(format ?? "G", formatProvider);
+
+    public override string ToString() => this.ToString(format: null, CultureInfo.InvariantCulture);
+
+    public bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider) =>
+        this.serialNumber.TryFormat(destination, out charsWritten, format.Length == 0 ? "G" : format, provider);
+
+    private static Option<NumberFirstSerialNumber<TNumber, BB26>>
+        Validate(Option<NumberFirstSerialNumber<TNumber, BB26>> serialNumber) =>
+        serialNumber.Bind(x => TNumber.IsZero(x.Number) ? None : Some(x));
+}


### PR DESCRIPTION
## Summary
- Added `OneANotation<TNumber>` as the number-first counterpart to `A1Notation<TNumber>`.
- Added reusable `NumberFirstSerialNumber<TNumber, TSerial>` to parse and format `number + serial` values.
- Supported input/output now includes compact forms like `1A` and hyphenated forms like `1-A`.
- Kept compact formatting as the default, with `