### PR TITLE
Sync DLL version metadata with NuGet package version

### DIFF
--- a/TIKSN.Framework.Core.Tests/Licensing/LicenseTests.cs
+++ b/TIKSN.Framework.Core.Tests/Licensing/LicenseTests.cs
@@ -511,6 +511,35 @@ public class LicenseTests
         this.AssertFail(result);
     }
 
+    private static LicenseEnvelope CreateEnvelope(
+        ILicenseFactory<TestEntitlements, TestLicenseEntitlements> licenseFactory,
+        LicenseTerms terms,
+        TestEntitlements entitlements,
+        X509Certificate2 privateCertificate)
+    {
+        var license = licenseFactory.Create(terms, entitlements, privateCertificate).SuccessToSeq().Single();
+        return LicenseEnvelope.Parser.ParseFrom([.. license.Data]);
+    }
+
+    private static Seq<byte> Resign(
+        LicenseEnvelope envelope,
+        string kind,
+        X509Certificate2 privateCertificate)
+    {
+        ICertificateSignatureService signatureService = kind switch
+        {
+            "RSA" => new RSACertificateSignatureService(),
+            "DSA" => new DSACertificateSignatureService(),
+            "EdDSA" => new EdDSACertificateSignatureService(),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),
+        };
+
+        envelope.SignatureAlgorithm = privateCertificate.GetKeyAlgorithm();
+        envelope.Signature =
+            ByteString.CopyFrom(signatureService.Sign(envelope.Message.ToByteArray(), privateCertificate));
+        return ToSeq(envelope);
+    }
+
     private static Seq<byte> ToSeq(
         IMessage message) => message.ToByteArray().ToSeq();
 
@@ -636,34 +665,5 @@ public class LicenseTests
         result.SuccessToSeq().Single().Terms.NotAfter.ShouldBe(terms.NotAfter);
         result.SuccessToSeq().Single().Data.ShouldNotBeEmpty();
         this.testOutputHelper.WriteLine($"License Data Length: {result.SuccessToSeq().Single().Data.Length}");
-    }
-
-    private static LicenseEnvelope CreateEnvelope(
-        ILicenseFactory<TestEntitlements, TestLicenseEntitlements> licenseFactory,
-        LicenseTerms terms,
-        TestEntitlements entitlements,
-        X509Certificate2 privateCertificate)
-    {
-        var license = licenseFactory.Create(terms, entitlements, privateCertificate).SuccessToSeq().Single();
-        return LicenseEnvelope.Parser.ParseFrom([.. license.Data]);
-    }
-
-    private static Seq<byte> Resign(
-        LicenseEnvelope envelope,
-        string kind,
-        X509Certificate2 privateCertificate)
-    {
-        ICertificateSignatureService signatureService = kind switch
-        {
-            "RSA" => new RSACertificateSignatureService(),
-            "DSA" => new DSACertificateSignatureService(),
-            "EdDSA" => new EdDSACertificateSignatureService(),
-            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, message: null),
-        };
-
-        envelope.SignatureAlgorithm = privateCertificate.GetKeyAlgorithm();
-        envelope.Signature =
-            ByteString.CopyFrom(signatureService.Sign(envelope.Message.ToByteArray(), privateCertificate));
-        return ToSeq(envelope);
     }
 }

--- a/TIKSN.Framework.Core/TIKSN.Framework.Core.csproj
+++ b/TIKSN.Framework.Core/TIKSN.Framework.Core.csproj
@@ -5,7 +5,9 @@
     <DocumentationFile>bin\$(Configuration)\net10.0\TIKSN.Framework.Core.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>TIKSN Development</Authors>
     <RootNamespace>TIKSN</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/TIKSN.Framework.Maui/TIKSN.Framework.Maui.csproj
+++ b/TIKSN.Framework.Maui/TIKSN.Framework.Maui.csproj
@@ -14,7 +14,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>TIKSN Development</Authors>
     <RootNamespace>TIKSN</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
+++ b/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
@@ -11,7 +11,10 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>TIKSN Development</Authors>
     <RootNamespace>TIKSN</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
+++ b/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
@@ -11,7 +11,10 @@
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
   <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Authors>TIKSN Development</Authors>
     <RootNamespace>TIKSN</RootNamespace>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary
- Re-enable SDK-generated assembly metadata for the packaged projects so the build version flows into the DLLs
- Disable source revision suffixes so `AssemblyInformationalVersion` stays aligned with the NuGet package version
- Keep existing manual assembly attributes where needed to avoid duplicate attribute errors
- Clean up duplicated helper methods in `LicenseTests`

## Testing
- Built the affected projects with an explicit version to confirm the generated DLL metadata reflects the package version
- Verified the updated test project still compiles after the `LicenseTests` refactor