### PR TITLE
Add CountryInfo factory and globalization lookups

### DIFF
--- a/TIKSN.Framework.Core.Tests/Globalization/CountryFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CountryFactoryTests.cs
@@ -1,0 +1,464 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class CountryFactoryTests
+{
+    [Fact]
+    public void GivenAggregateRegion_WhenCountryCreated_ThenItShouldThrow()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act & Assert
+
+        _ = Should.Throw<CountryNotFoundException>(() => countryFactory.Create("001"));
+    }
+
+    [Fact]
+    public void GivenAggregateRegion_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var created = countryFactory.TryCreate("001", out var country);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        country.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenConfiguredOptionsWithoutPrincipalRegion_WhenCountryCreated_ThenItShouldThrow()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory(options => options.CountryRegions["DE"] = ["GU"]);
+
+        // Act & Assert
+
+        _ = Should.Throw<ArgumentException>(() => countryFactory.Create("DE"));
+    }
+
+    [Fact]
+    public void GivenConfiguredOptions_WhenCountryCreated_ThenConfiguredMappingsShouldOverrideDefaults()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory(options =>
+        {
+            options.CountryRegions["US"] = ["US"];
+            options.CountryRegions["DE"] = ["DE", "GU"];
+        });
+
+        // Act
+
+        var unitedStates = countryFactory.Create("US");
+        var germany = countryFactory.Create("GU");
+
+        // Assert
+
+        unitedStates.Regions.Select(x => x.TwoLetterISORegionName).ShouldBe(["US"]);
+        germany.Name.ShouldBe("DE");
+        germany.Regions.Select(x => x.TwoLetterISORegionName).ShouldBe(["DE", "GU"]);
+    }
+
+    [Theory]
+    [InlineData("PL", "PL", 1)]
+    [InlineData("US", "US", 7)]
+    [InlineData("FR", "FR", 12)]
+    [InlineData("GB", "GB", 15)]
+    [InlineData("NL", "NL", 5)]
+    [InlineData("CN", "CN", 3)]
+    [InlineData("FI", "FI", 2)]
+    [InlineData("NO", "NO", 2)]
+    public void GivenCountryCode_WhenCountryCreated_ThenItShouldMatchDefaultMap(
+        string input,
+        string expectedCountryName,
+        int expectedRegionCount)
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create(input);
+
+        // Assert
+
+        country.Name.ShouldBe(expectedCountryName);
+        country.TwoLetterISORegionName.ShouldBe(expectedCountryName);
+        country.PrincipalRegion.TwoLetterISORegionName.ShouldBe(expectedCountryName);
+        country.Regions.Count.ShouldBe(expectedRegionCount);
+        country.ContainsRegion(country.PrincipalRegion).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenCultureName_WhenCountryCreated_ThenCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create("en-US");
+
+        // Assert
+
+        country.Name.ShouldBe("US");
+    }
+
+    [Theory]
+    [InlineData("GB", 15, "GB")]
+    [InlineData("FR", 12, "FR")]
+    [InlineData("US", 7, "US")]
+    [InlineData("NL", 5, "NL")]
+    [InlineData("AU", 4, "AU")]
+    [InlineData("NZ", 4, "NZ")]
+    [InlineData("CN", 3, "CN")]
+    [InlineData("DK", 3, "DK")]
+    [InlineData("FI", 2, "FI")]
+    [InlineData("NO", 2, "NO")]
+    [InlineData("AD", 1, "AD")]
+    [InlineData("AE", 1, "AE")]
+    [InlineData("AF", 1, "AF")]
+    [InlineData("AG", 1, "AG")]
+    [InlineData("AL", 1, "AL")]
+    [InlineData("AM", 1, "AM")]
+    [InlineData("AO", 1, "AO")]
+    [InlineData("AR", 1, "AR")]
+    [InlineData("AT", 1, "AT")]
+    [InlineData("AZ", 1, "AZ")]
+    [InlineData("BA", 1, "BA")]
+    [InlineData("BB", 1, "BB")]
+    [InlineData("BD", 1, "BD")]
+    [InlineData("BE", 1, "BE")]
+    [InlineData("BF", 1, "BF")]
+    [InlineData("BG", 1, "BG")]
+    [InlineData("BH", 1, "BH")]
+    [InlineData("BI", 1, "BI")]
+    [InlineData("BJ", 1, "BJ")]
+    [InlineData("BN", 1, "BN")]
+    [InlineData("BO", 1, "BO")]
+    [InlineData("BR", 1, "BR")]
+    [InlineData("BS", 1, "BS")]
+    [InlineData("BT", 1, "BT")]
+    [InlineData("BW", 1, "BW")]
+    [InlineData("BY", 1, "BY")]
+    [InlineData("BZ", 1, "BZ")]
+    [InlineData("CA", 1, "CA")]
+    [InlineData("CD", 1, "CD")]
+    [InlineData("CF", 1, "CF")]
+    [InlineData("CG", 1, "CG")]
+    [InlineData("CH", 1, "CH")]
+    [InlineData("CI", 1, "CI")]
+    [InlineData("CL", 1, "CL")]
+    [InlineData("CM", 1, "CM")]
+    [InlineData("CO", 1, "CO")]
+    [InlineData("CR", 1, "CR")]
+    [InlineData("CU", 1, "CU")]
+    [InlineData("CV", 1, "CV")]
+    [InlineData("CY", 1, "CY")]
+    [InlineData("CZ", 1, "CZ")]
+    [InlineData("DE", 1, "DE")]
+    [InlineData("DJ", 1, "DJ")]
+    [InlineData("DM", 1, "DM")]
+    [InlineData("DO", 1, "DO")]
+    [InlineData("DZ", 1, "DZ")]
+    [InlineData("EC", 1, "EC")]
+    [InlineData("EE", 1, "EE")]
+    [InlineData("EG", 1, "EG")]
+    [InlineData("ER", 1, "ER")]
+    [InlineData("ES", 1, "ES")]
+    [InlineData("ET", 1, "ET")]
+    [InlineData("FJ", 1, "FJ")]
+    [InlineData("FM", 1, "FM")]
+    [InlineData("GA", 1, "GA")]
+    [InlineData("GD", 1, "GD")]
+    [InlineData("GE", 1, "GE")]
+    [InlineData("GH", 1, "GH")]
+    [InlineData("GM", 1, "GM")]
+    [InlineData("GN", 1, "GN")]
+    [InlineData("GQ", 1, "GQ")]
+    [InlineData("GR", 1, "GR")]
+    [InlineData("GT", 1, "GT")]
+    [InlineData("GW", 1, "GW")]
+    [InlineData("GY", 1, "GY")]
+    [InlineData("HN", 1, "HN")]
+    [InlineData("HR", 1, "HR")]
+    [InlineData("HT", 1, "HT")]
+    [InlineData("HU", 1, "HU")]
+    [InlineData("ID", 1, "ID")]
+    [InlineData("IE", 1, "IE")]
+    [InlineData("IL", 1, "IL")]
+    [InlineData("IN", 1, "IN")]
+    [InlineData("IQ", 1, "IQ")]
+    [InlineData("IR", 1, "IR")]
+    [InlineData("IS", 1, "IS")]
+    [InlineData("IT", 1, "IT")]
+    [InlineData("JM", 1, "JM")]
+    [InlineData("JO", 1, "JO")]
+    [InlineData("JP", 1, "JP")]
+    [InlineData("KE", 1, "KE")]
+    [InlineData("KG", 1, "KG")]
+    [InlineData("KH", 1, "KH")]
+    [InlineData("KI", 1, "KI")]
+    [InlineData("KM", 1, "KM")]
+    [InlineData("KN", 1, "KN")]
+    [InlineData("KP", 1, "KP")]
+    [InlineData("KR", 1, "KR")]
+    [InlineData("KW", 1, "KW")]
+    [InlineData("KZ", 1, "KZ")]
+    [InlineData("LA", 1, "LA")]
+    [InlineData("LB", 1, "LB")]
+    [InlineData("LC", 1, "LC")]
+    [InlineData("LI", 1, "LI")]
+    [InlineData("LK", 1, "LK")]
+    [InlineData("LR", 1, "LR")]
+    [InlineData("LS", 1, "LS")]
+    [InlineData("LT", 1, "LT")]
+    [InlineData("LU", 1, "LU")]
+    [InlineData("LV", 1, "LV")]
+    [InlineData("LY", 1, "LY")]
+    [InlineData("MA", 1, "MA")]
+    [InlineData("MC", 1, "MC")]
+    [InlineData("MD", 1, "MD")]
+    [InlineData("ME", 1, "ME")]
+    [InlineData("MG", 1, "MG")]
+    [InlineData("MH", 1, "MH")]
+    [InlineData("MK", 1, "MK")]
+    [InlineData("ML", 1, "ML")]
+    [InlineData("MM", 1, "MM")]
+    [InlineData("MN", 1, "MN")]
+    [InlineData("MR", 1, "MR")]
+    [InlineData("MT", 1, "MT")]
+    [InlineData("MU", 1, "MU")]
+    [InlineData("MV", 1, "MV")]
+    [InlineData("MW", 1, "MW")]
+    [InlineData("MX", 1, "MX")]
+    [InlineData("MY", 1, "MY")]
+    [InlineData("MZ", 1, "MZ")]
+    [InlineData("NA", 1, "NA")]
+    [InlineData("NE", 1, "NE")]
+    [InlineData("NG", 1, "NG")]
+    [InlineData("NI", 1, "NI")]
+    [InlineData("NP", 1, "NP")]
+    [InlineData("NR", 1, "NR")]
+    [InlineData("OM", 1, "OM")]
+    [InlineData("PA", 1, "PA")]
+    [InlineData("PE", 1, "PE")]
+    [InlineData("PG", 1, "PG")]
+    [InlineData("PH", 1, "PH")]
+    [InlineData("PK", 1, "PK")]
+    [InlineData("PL", 1, "PL")]
+    [InlineData("PS", 1, "PS")]
+    [InlineData("PT", 1, "PT")]
+    [InlineData("PW", 1, "PW")]
+    [InlineData("PY", 1, "PY")]
+    [InlineData("QA", 1, "QA")]
+    [InlineData("RO", 1, "RO")]
+    [InlineData("RS", 1, "RS")]
+    [InlineData("RU", 1, "RU")]
+    [InlineData("RW", 1, "RW")]
+    [InlineData("SA", 1, "SA")]
+    [InlineData("SB", 1, "SB")]
+    [InlineData("SC", 1, "SC")]
+    [InlineData("SD", 1, "SD")]
+    [InlineData("SE", 1, "SE")]
+    [InlineData("SG", 1, "SG")]
+    [InlineData("SI", 1, "SI")]
+    [InlineData("SK", 1, "SK")]
+    [InlineData("SL", 1, "SL")]
+    [InlineData("SM", 1, "SM")]
+    [InlineData("SN", 1, "SN")]
+    [InlineData("SO", 1, "SO")]
+    [InlineData("SR", 1, "SR")]
+    [InlineData("SS", 1, "SS")]
+    [InlineData("ST", 1, "ST")]
+    [InlineData("SV", 1, "SV")]
+    [InlineData("SY", 1, "SY")]
+    [InlineData("SZ", 1, "SZ")]
+    [InlineData("TD", 1, "TD")]
+    [InlineData("TG", 1, "TG")]
+    [InlineData("TH", 1, "TH")]
+    [InlineData("TJ", 1, "TJ")]
+    [InlineData("TL", 1, "TL")]
+    [InlineData("TM", 1, "TM")]
+    [InlineData("TN", 1, "TN")]
+    [InlineData("TO", 1, "TO")]
+    [InlineData("TR", 1, "TR")]
+    [InlineData("TT", 1, "TT")]
+    [InlineData("TV", 1, "TV")]
+    [InlineData("TW", 1, "TW")]
+    [InlineData("TZ", 1, "TZ")]
+    [InlineData("UA", 1, "UA")]
+    [InlineData("UG", 1, "UG")]
+    [InlineData("UY", 1, "UY")]
+    [InlineData("UZ", 1, "UZ")]
+    [InlineData("VA", 1, "VA")]
+    [InlineData("VC", 1, "VC")]
+    [InlineData("VE", 1, "VE")]
+    [InlineData("VN", 1, "VN")]
+    [InlineData("VU", 1, "VU")]
+    [InlineData("WS", 1, "WS")]
+    [InlineData("XK", 1, "XK")]
+    [InlineData("YE", 1, "YE")]
+    [InlineData("ZA", 1, "ZA")]
+    [InlineData("ZM", 1, "ZM")]
+    [InlineData("ZW", 1, "ZW")]
+    public void GivenDefaultMapCountry_WhenCountryCreated_ThenPrincipalRegionAndRegionCountShouldMatch(
+        string input,
+        int expectedRegionCount,
+        string expectedPrincipalRegion)
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create(input);
+
+        // Assert
+
+        country.PrincipalRegion.TwoLetterISORegionName.ShouldBe(expectedPrincipalRegion);
+        country.Regions.Count.ShouldBe(expectedRegionCount);
+        country.ContainsRegion(expectedPrincipalRegion).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenInvalidRegionName_WhenCountryCreated_ThenItShouldThrowCountryNotFoundException()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act & Assert
+
+        _ = Should.Throw<CountryNotFoundException>(() => countryFactory.Create("this is not a region"));
+    }
+
+    [Fact]
+    public void GivenInvalidRegionName_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var created = countryFactory.TryCreate("this is not a region", out var country);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        country.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenMissingConcreteRegion_WhenCountryCreated_ThenItShouldFallbackToSingleRegionCountry()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create("AQ");
+
+        // Assert
+
+        country.Name.ShouldBe("AQ");
+        country.PrincipalRegion.TwoLetterISORegionName.ShouldBe("AQ");
+        country.Regions.Single().TwoLetterISORegionName.ShouldBe("AQ");
+    }
+
+    [Theory]
+    [InlineData("GU", "US")]
+    [InlineData("AS", "US")]
+    [InlineData("GF", "FR")]
+    [InlineData("SX", "NL")]
+    [InlineData("HK", "CN")]
+    [InlineData("AX", "FI")]
+    [InlineData("SJ", "NO")]
+    public void GivenRegionCode_WhenCountryCreated_ThenParentCountryShouldBeReturned(
+        string input,
+        string expectedCountryName)
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create(input);
+
+        // Assert
+
+        country.Name.ShouldBe(expectedCountryName);
+        country.ContainsRegion(input).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenRegionInfoForTerritory_WhenCountryCreated_ThenParentCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var country = countryFactory.Create(new RegionInfo("GU"));
+
+        // Assert
+
+        country.Name.ShouldBe("US");
+        country.ContainsRegion("GU").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenSameCountryAndRegion_WhenCountryCreated_ThenCachedInstanceShouldBeReturned()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+
+        // Act
+
+        var fromCountry = countryFactory.Create("US");
+        var fromRegion = countryFactory.Create("GU");
+        var fromCulture = countryFactory.Create(new RegionInfo("en-US"));
+
+        // Assert
+
+        fromRegion.ShouldBeSameAs(fromCountry);
+        fromCulture.ShouldBeSameAs(fromCountry);
+    }
+
+    private static ICountryFactory CreateCountryFactory(Action<CountryInfoOptions> configure = null)
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        if (configure != null)
+        {
+            _ = services.Configure(configure);
+        }
+
+        var serviceProvider = services.BuildServiceProvider();
+        return serviceProvider.GetRequiredService<ICountryFactory>();
+    }
+}

--- a/TIKSN.Framework.Core.Tests/Globalization/CountryInfoTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CountryInfoTests.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class CountryInfoTests
+{
+    [Fact]
+    public void GivenCountry_WhenComparedToDifferentObject_ThenItShouldNotBeEqual()
+    {
+        // Arrange
+
+        var country = CreateCountryFactory().Create("US");
+
+        // Act & Assert
+
+        country.Equals(new object()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenCountry_WhenComparedToNull_ThenItShouldNotBeEqual()
+    {
+        // Arrange
+
+        var country = CreateCountryFactory().Create("US");
+        CountryInfo nullCountry = null;
+
+        // Act & Assert
+
+        country.Equals(nullCountry).ShouldBeFalse();
+        (country == nullCountry).ShouldBeFalse();
+        (country != nullCountry).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenCountry_WhenPropertiesRead_ThenItShouldExposeCountryInformation()
+    {
+        // Arrange
+
+        var country = CreateCountryFactory().Create("US");
+
+        // Act & Assert
+
+        country.Name.ShouldBe("US");
+        country.TwoLetterISORegionName.ShouldBe("US");
+        country.PrincipalRegion.TwoLetterISORegionName.ShouldBe("US");
+        country.Regions.Select(x => x.TwoLetterISORegionName).ShouldBe(["AS", "GU", "MP", "PR", "UM", "US", "VI"]);
+        country.ToString().ShouldBe("US");
+    }
+
+    [Fact]
+    public void GivenCountry_WhenRegionChecked_ThenMembershipShouldBeEvaluated()
+    {
+        // Arrange
+
+        var country = CreateCountryFactory().Create("US");
+
+        // Act & Assert
+
+        country.ContainsRegion("US").ShouldBeTrue();
+        country.ContainsRegion("en-US").ShouldBeTrue();
+        country.ContainsRegion(new RegionInfo("GU")).ShouldBeTrue();
+        country.ContainsRegion("PL").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenCountry_WhenRegionsRead_ThenCollectionShouldBeImmutable()
+    {
+        // Arrange
+
+        var country = CreateCountryFactory().Create("US");
+
+        // Act & Assert
+
+        country.Regions.ShouldBeAssignableTo<System.Collections.ObjectModel.ReadOnlyCollection<RegionInfo>>();
+    }
+
+    [Fact]
+    public void GivenDifferentCountryName_WhenCompared_ThenCountriesShouldNotBeEqual()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+        var unitedStates = countryFactory.Create("US");
+        var poland = countryFactory.Create("PL");
+
+        // Act & Assert
+
+        unitedStates.Equals(poland).ShouldBeFalse();
+        (unitedStates != poland).ShouldBeTrue();
+        (unitedStates == poland).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GivenSameCountryName_WhenCompared_ThenCountriesShouldBeEqual()
+    {
+        // Arrange
+
+        var countryFactory = CreateCountryFactory();
+        var unitedStates1 = countryFactory.Create("US");
+        var unitedStates2 = countryFactory.Create(new RegionInfo("en-US"));
+
+        // Act & Assert
+
+        unitedStates1.Equals(unitedStates2).ShouldBeTrue();
+        (unitedStates1 == unitedStates2).ShouldBeTrue();
+        (unitedStates1 != unitedStates2).ShouldBeFalse();
+        unitedStates1.GetHashCode().ShouldBe(unitedStates2.GetHashCode());
+    }
+
+    private static ICountryFactory CreateCountryFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        return serviceProvider.GetRequiredService<ICountryFactory>();
+    }
+}

--- a/TIKSN.Framework.Core.Tests/Globalization/CultureFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CultureFactoryTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class CultureFactoryTests
+{
+    [Fact]
+    public void GivenInvalidCultureName_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var cultureFactory = CreateCultureFactory();
+
+        // Act
+
+        var created = cultureFactory.TryCreate("this is not valid", out var culture);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        culture.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullCultureName_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var cultureFactory = CreateCultureFactory();
+        string name = null;
+
+        // Act
+
+        var created = cultureFactory.TryCreate(name, out var culture);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        culture.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenValidCultureName_WhenTryCreateCalled_ThenItShouldReturnCulture()
+    {
+        // Arrange
+
+        var cultureFactory = CreateCultureFactory();
+
+        // Act
+
+        var created = cultureFactory.TryCreate("en-US", out var culture);
+
+        // Assert
+
+        created.ShouldBeTrue();
+        culture.ShouldNotBeNull();
+        culture.Name.ShouldBe("en-US");
+    }
+
+    private static ICultureFactory CreateCultureFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        return serviceProvider.GetRequiredService<ICultureFactory>();
+    }
+}

--- a/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
@@ -130,4 +130,108 @@ public class CurrencyFactoryTests
         _ = currencyInfo.ShouldNotBeNull();
         currencyInfo.ISOCurrencySymbol.ShouldBe(outputIsoCurrencySymbol);
     }
+
+    [Fact]
+    public void GivenInvalidIsoCurrencySymbol_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+
+        // Act
+
+        var created = currencyFactory.TryCreate("ZZZ", out var currency);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        currency.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullIsoCurrencySymbol_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        string isoCurrencySymbol = null;
+
+        // Act
+
+        var created = currencyFactory.TryCreate(isoCurrencySymbol, out var currency);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        currency.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullRegion_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        RegionInfo region = null;
+
+        // Act
+
+        var created = currencyFactory.TryCreate(region, out var currency);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        currency.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenValidIsoCurrencySymbol_WhenTryCreateCalled_ThenItShouldReturnCurrency()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+
+        // Act
+
+        var created = currencyFactory.TryCreate("USD", out var currency);
+
+        // Assert
+
+        created.ShouldBeTrue();
+        currency.ShouldNotBeNull();
+        currency.ISOCurrencySymbol.ShouldBe("USD");
+    }
+
+    [Fact]
+    public void GivenValidRegion_WhenTryCreateCalled_ThenItShouldReturnCurrency()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+
+        // Act
+
+        var created = currencyFactory.TryCreate(new RegionInfo("US"), out var currency);
+
+        // Assert
+
+        created.ShouldBeTrue();
+        currency.ShouldNotBeNull();
+        currency.ISOCurrencySymbol.ShouldBe("USD");
+    }
 }

--- a/TIKSN.Framework.Core.Tests/Globalization/RegionFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/RegionFactoryTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class RegionFactoryTests
+{
+    [Fact]
+    public void GivenInvalidRegionName_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var regionFactory = CreateRegionFactory();
+
+        // Act
+
+        var created = regionFactory.TryCreate("not-a-region", out var region);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        region.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullRegionName_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var regionFactory = CreateRegionFactory();
+        string name = null;
+
+        // Act
+
+        var created = regionFactory.TryCreate(name, out var region);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        region.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenValidCultureName_WhenTryCreateCalled_ThenItShouldReturnRegion()
+    {
+        // Arrange
+
+        var regionFactory = CreateRegionFactory();
+
+        // Act
+
+        var created = regionFactory.TryCreate("en-US", out var region);
+
+        // Assert
+
+        created.ShouldBeTrue();
+        region.ShouldNotBeNull();
+        region.TwoLetterISORegionName.ShouldBe("US");
+    }
+
+    [Fact]
+    public void GivenValidRegionName_WhenTryCreateCalled_ThenItShouldReturnRegion()
+    {
+        // Arrange
+
+        var regionFactory = CreateRegionFactory();
+
+        // Act
+
+        var created = regionFactory.TryCreate("US", out var region);
+
+        // Assert
+
+        created.ShouldBeTrue();
+        region.ShouldNotBeNull();
+        region.TwoLetterISORegionName.ShouldBe("US");
+    }
+
+    private static IRegionFactory CreateRegionFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        return serviceProvider.GetRequiredService<IRegionFactory>();
+    }
+}

--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         _ = services.AddOptions();
 
         services.TryAddSingleton<ICultureFactory, CultureFactory>();
+        services.TryAddSingleton<ICountryFactory, CountryFactory>();
         services.TryAddSingleton<ICurrencyFactory, CurrencyFactory>();
         services.TryAddSingleton<IRegionFactory, RegionFactory>();
         services.TryAddSingleton<IResourceNamesCache, ResourceNamesCache>();

--- a/TIKSN.Framework.Core/Globalization/CountryFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/CountryFactory.cs
@@ -1,0 +1,208 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using TIKSN.Data.Cache.Memory;
+
+namespace TIKSN.Globalization;
+
+public class CountryFactory : MemoryCacheDecoratorBase<CountryInfo>, ICountryFactory
+{
+    private readonly IOptions<CountryInfoOptions> countryInfoOptions;
+    private readonly IRegionFactory regionFactory;
+
+    public CountryFactory(
+        IMemoryCache memoryCache,
+        IRegionFactory regionFactory,
+        IOptions<CountryInfoOptions> countryInfoOptions,
+        IOptions<MemoryCacheDecoratorOptions> genericOptions,
+        IOptions<MemoryCacheDecoratorOptions<CountryInfo>> specificOptions) : base(memoryCache, genericOptions,
+        specificOptions)
+    {
+        this.regionFactory = regionFactory ?? throw new ArgumentNullException(nameof(regionFactory));
+        this.countryInfoOptions = countryInfoOptions ?? throw new ArgumentNullException(nameof(countryInfoOptions));
+    }
+
+    public CountryInfo Create(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new CountryNotFoundException("Country name cannot be null or whitespace.");
+        }
+
+        RegionInfo region;
+        try
+        {
+            region = this.regionFactory.Create(name);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new CountryNotFoundException($"Country '{name}' was not found.", ex);
+        }
+
+        return this.Create(region);
+    }
+
+    public CountryInfo Create(RegionInfo region)
+    {
+        if (region is null)
+        {
+            throw new CountryNotFoundException("Country region cannot be null.");
+        }
+
+        var countryName = this.ResolveCountryName(region);
+        var cacheKey = Tuple.Create(EntityType, countryName);
+
+        return this.GetFromMemoryCache(cacheKey, () => this.CreateCountry(countryName))
+            ?? throw new InvalidOperationException("Failed to create CountryInfo.");
+    }
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out CountryInfo? country)
+    {
+        try
+        {
+            country = this.Create(name);
+            return true;
+        }
+        catch (CountryNotFoundException)
+        {
+            country = null;
+            return false;
+        }
+    }
+
+    public bool TryCreate(RegionInfo region, [NotNullWhen(true)] out CountryInfo? country)
+    {
+        try
+        {
+            country = this.Create(region);
+            return true;
+        }
+        catch (CountryNotFoundException)
+        {
+            country = null;
+            return false;
+        }
+    }
+
+    private static string NormalizeCode(string code)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+
+        return code.Trim().ToUpperInvariant();
+    }
+
+    private static string[] ParseRegionNames(IEnumerable<string> regionNames)
+    {
+        if (regionNames is null)
+        {
+            throw new ArgumentNullException(nameof(regionNames), "Country regions cannot be null.");
+        }
+
+        return [.. regionNames
+            .Select(NormalizeCode)
+            .Distinct(StringComparer.Ordinal)];
+    }
+
+    private static void ValidateConfiguredConcreteRegionCode(string code)
+    {
+        if (code.Length != 2)
+        {
+            throw new ArgumentException($"Region '{code}' is not a concrete two-letter region.", nameof(code));
+        }
+
+        RegionInfo region;
+        try
+        {
+            region = new RegionInfo(code);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"Region '{code}' is not a concrete two-letter region.", nameof(code), ex);
+        }
+
+        if (!string.Equals(region.TwoLetterISORegionName, code, StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"Region '{code}' is not a concrete two-letter region.", nameof(code));
+        }
+    }
+
+    private static void ValidateCountryRegionMapping(string countryName, string[] regionNames)
+    {
+        ValidateConfiguredConcreteRegionCode(countryName);
+
+        if (regionNames.Length == 0)
+        {
+            throw new ArgumentException($"Country '{countryName}' must contain at least one region.",
+                nameof(regionNames));
+        }
+
+        foreach (var regionName in regionNames)
+        {
+            ValidateConfiguredConcreteRegionCode(regionName);
+        }
+
+        if (!regionNames.Contains(countryName, StringComparer.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Country '{countryName}' must include its principal region.",
+                nameof(regionNames));
+        }
+    }
+
+    private CountryInfo CreateCountry(string countryName)
+    {
+        var countryRegions = this.GetCountryRegions();
+        if (!countryRegions.TryGetValue(countryName, out var regionNames))
+        {
+            regionNames = [countryName];
+        }
+
+        ValidateCountryRegionMapping(countryName, regionNames);
+
+        var principalRegion = this.regionFactory.Create(countryName);
+        var regions = regionNames.Select(this.regionFactory.Create).ToArray();
+
+        return new CountryInfo(countryName, principalRegion, regions);
+    }
+
+    private Dictionary<string, string[]> GetCountryRegions()
+    {
+        var countryRegions = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        foreach (var configuredCountryRegions in this.countryInfoOptions.Value.CountryRegions)
+        {
+            countryRegions[NormalizeCode(configuredCountryRegions.Key)] =
+                ParseRegionNames(configuredCountryRegions.Value);
+        }
+
+        return countryRegions;
+    }
+
+    private string ResolveCountryName(RegionInfo region)
+    {
+        var regionName = region.TwoLetterISORegionName;
+        if (regionName.Length != 2)
+        {
+            throw new CountryNotFoundException($"Region '{region.Name}' is not a concrete two-letter region.");
+        }
+
+        var countryRegions = this.GetCountryRegions();
+        if (countryRegions.ContainsKey(regionName))
+        {
+            return regionName;
+        }
+
+        var containingCountries = countryRegions
+            .Where(x => x.Value.Contains(regionName, StringComparer.Ordinal))
+            .Select(x => x.Key)
+            .ToArray();
+
+        if (containingCountries.Length > 1)
+        {
+            throw new CountryNotFoundException($"Region '{region.Name}' is configured for multiple countries.");
+        }
+
+        return containingCountries.Length == 1 ? containingCountries[0] : regionName;
+    }
+}

--- a/TIKSN.Framework.Core/Globalization/CountryInfo.cs
+++ b/TIKSN.Framework.Core/Globalization/CountryInfo.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+
+namespace TIKSN.Globalization;
+
+public sealed class CountryInfo : IEquatable<CountryInfo>
+{
+    private readonly HashSet<string> regionNames;
+
+    internal CountryInfo(string name, RegionInfo principalRegion, IReadOnlyCollection<RegionInfo> regions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(principalRegion);
+        ArgumentNullException.ThrowIfNull(regions);
+
+        this.Name = name;
+        this.TwoLetterISORegionName = name;
+        this.PrincipalRegion = principalRegion;
+        this.Regions = Array.AsReadOnly(regions.ToArray());
+        this.regionNames = [.. this.Regions.Select(x => x.TwoLetterISORegionName)];
+
+        if (!this.regionNames.Contains(this.PrincipalRegion.TwoLetterISORegionName))
+        {
+            throw new ArgumentException(
+                $"Country '{this.Name}' regions must include its principal region.",
+                nameof(regions));
+        }
+    }
+
+    public string Name { get; }
+
+    public RegionInfo PrincipalRegion { get; }
+
+    public IReadOnlyCollection<RegionInfo> Regions { get; }
+
+    public string TwoLetterISORegionName { get; }
+
+    public static bool operator ==(CountryInfo? first, CountryInfo? second) => Equals(first, second);
+
+    public static bool operator !=(CountryInfo? first, CountryInfo? second) => !Equals(first, second);
+
+    public bool ContainsRegion(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return this.ContainsRegion(new RegionInfo(name));
+    }
+
+    public bool ContainsRegion(RegionInfo region)
+    {
+        ArgumentNullException.ThrowIfNull(region);
+
+        return this.regionNames.Contains(region.TwoLetterISORegionName);
+    }
+
+    public bool Equals(CountryInfo? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(this.Name, other.Name, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (obj is not CountryInfo that)
+        {
+            return false;
+        }
+
+        return this.Equals(that);
+    }
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(this.Name);
+
+    public override string ToString() => this.Name;
+}

--- a/TIKSN.Framework.Core/Globalization/CountryInfoOptions.cs
+++ b/TIKSN.Framework.Core/Globalization/CountryInfoOptions.cs
@@ -1,0 +1,21 @@
+namespace TIKSN.Globalization;
+
+public class CountryInfoOptions
+{
+    public CountryInfoOptions()
+        => this.CountryRegions = new Dictionary<string, List<string>>(StringComparer.Ordinal)
+        {
+            { "GB", ["AI", "BM", "FK", "GB", "GG", "GI", "IM", "IO", "JE", "KY", "MS", "PN", "SH", "TC", "VG"] },
+            { "FR", ["BL", "FR", "GF", "GP", "MF", "MQ", "NC", "PF", "PM", "RE", "WF", "YT"] },
+            { "US", ["AS", "GU", "MP", "PR", "UM", "US", "VI"] },
+            { "NL", ["AW", "BQ", "CW", "NL", "SX"] },
+            { "AU", ["AU", "CC", "CX", "NF"] },
+            { "NZ", ["CK", "NU", "NZ", "TK"] },
+            { "CN", ["CN", "HK", "MO"] },
+            { "DK", ["DK", "FO", "GL"] },
+            { "FI", ["AX", "FI"] },
+            { "NO", ["NO", "SJ"] },
+        };
+
+    public IDictionary<string, List<string>> CountryRegions { get; }
+}

--- a/TIKSN.Framework.Core/Globalization/CountryNotFoundException.cs
+++ b/TIKSN.Framework.Core/Globalization/CountryNotFoundException.cs
@@ -1,0 +1,16 @@
+namespace TIKSN.Globalization;
+
+public class CountryNotFoundException : Exception
+{
+    public CountryNotFoundException()
+    {
+    }
+
+    public CountryNotFoundException(string message) : base(message)
+    {
+    }
+
+    public CountryNotFoundException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}

--- a/TIKSN.Framework.Core/Globalization/CultureFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/CultureFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -19,5 +20,19 @@ public class CultureFactory : MemoryCacheDecoratorBase<CultureInfo>, ICultureFac
 
         return this.GetFromMemoryCache(cacheKey, () => new CultureInfo(name))
             ?? throw new InvalidOperationException("Failed to create CultureInfo.");
+    }
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out CultureInfo? culture)
+    {
+        try
+        {
+            culture = this.Create(name);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            culture = null;
+            return false;
+        }
     }
 }

--- a/TIKSN.Framework.Core/Globalization/CurrencyFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/CurrencyFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -66,5 +67,43 @@ public class CurrencyFactory : MemoryCacheDecoratorBase<CurrencyInfo>, ICurrency
 
         return this.GetFromMemoryCache(cacheKey, () => new CurrencyInfo(region))
             ?? throw new InvalidOperationException("Failed to create CurrencyInfo.");
+    }
+
+    public bool TryCreate(string isoCurrencySymbol, [NotNullWhen(true)] out CurrencyInfo? currency)
+    {
+        try
+        {
+            currency = this.Create(isoCurrencySymbol);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            currency = null;
+            return false;
+        }
+        catch (CurrencyNotFoundException)
+        {
+            currency = null;
+            return false;
+        }
+    }
+
+    public bool TryCreate(RegionInfo region, [NotNullWhen(true)] out CurrencyInfo? currency)
+    {
+        try
+        {
+            currency = this.Create(region);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            currency = null;
+            return false;
+        }
+        catch (CurrencyNotFoundException)
+        {
+            currency = null;
+            return false;
+        }
     }
 }

--- a/TIKSN.Framework.Core/Globalization/ICountryFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/ICountryFactory.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace TIKSN.Globalization;
+
+public interface ICountryFactory
+{
+    public CountryInfo Create(string name);
+
+    public CountryInfo Create(RegionInfo region);
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out CountryInfo? country);
+
+    public bool TryCreate(RegionInfo region, [NotNullWhen(true)] out CountryInfo? country);
+}

--- a/TIKSN.Framework.Core/Globalization/ICultureFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/ICultureFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace TIKSN.Globalization;
@@ -5,4 +6,6 @@ namespace TIKSN.Globalization;
 public interface ICultureFactory
 {
     public CultureInfo Create(string name);
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out CultureInfo? culture);
 }

--- a/TIKSN.Framework.Core/Globalization/ICurrencyFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/ICurrencyFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using TIKSN.Finance;
 
@@ -8,4 +9,8 @@ public interface ICurrencyFactory
     public CurrencyInfo Create(string isoCurrencySymbol);
 
     public CurrencyInfo Create(RegionInfo region);
+
+    public bool TryCreate(string isoCurrencySymbol, [NotNullWhen(true)] out CurrencyInfo? currency);
+
+    public bool TryCreate(RegionInfo region, [NotNullWhen(true)] out CurrencyInfo? currency);
 }

--- a/TIKSN.Framework.Core/Globalization/IRegionFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/IRegionFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace TIKSN.Globalization;
@@ -5,4 +6,6 @@ namespace TIKSN.Globalization;
 public interface IRegionFactory
 {
     public RegionInfo Create(string name);
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out RegionInfo? region);
 }

--- a/TIKSN.Framework.Core/Globalization/RegionFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/RegionFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -19,5 +20,19 @@ public class RegionFactory : MemoryCacheDecoratorBase<RegionInfo>, IRegionFactor
 
         return this.GetFromMemoryCache(cacheKey, () => new RegionInfo(name))
             ?? throw new InvalidOperationException("Failed to create RegionInfo.");
+    }
+
+    public bool TryCreate(string name, [NotNullWhen(true)] out RegionInfo? region)
+    {
+        try
+        {
+            region = this.Create(name);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            region = null;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add immutable `CountryInfo` with factory-based creation, principal region tracking, region containment checks, and equality by country code
- Introduce `ICountryFactory`, `CountryFactory`, and `CountryNotFoundException` with DI registration in core services
- Add `TryCreate` APIs to culture, currency, and region factories for consistent non-throwing lookups
- Move built-in country/region mappings into `CountryInfoOptions` and keep fallback handling for 1:1 countries
- Expand globalization test coverage for country mappings, fallback behavior, options overrides, and invalid inputs

## Testing
- Added and updated unit tests for country, culture, currency, and region factory behavior
- Verified the globalization test suite and full core test suite locally