### PR TITLE
Add TimeZoneInfo lookup backed by TZDB geography

### DIFF
--- a/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
+++ b/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
@@ -41,6 +41,7 @@ public class RegistrationsTests : IDisposable
     [InlineData(typeof(IRegionFactory))]
     [InlineData(typeof(ICurrencyFactory))]
     [InlineData(typeof(IDateTimeZoneLookup))]
+    [InlineData(typeof(ITimeZoneInfoLookup))]
     public void GivenHost_WhenServiceResolved_ThenItShouldNotBeNull(Type serviceType)
     {
         var service = this.host.Services.GetRequiredService(serviceType);

--- a/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
+++ b/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
@@ -40,6 +40,7 @@ public class RegistrationsTests : IDisposable
     [InlineData(typeof(ICultureFactory))]
     [InlineData(typeof(IRegionFactory))]
     [InlineData(typeof(ICurrencyFactory))]
+    [InlineData(typeof(IDateTimeZoneLookup))]
     public void GivenHost_WhenServiceResolved_ThenItShouldNotBeNull(Type serviceType)
     {
         var service = this.host.Services.GetRequiredService(serviceType);

--- a/TIKSN.Framework.Core.Tests/Globalization/CountryInfoTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CountryInfoTests.cs
@@ -77,7 +77,7 @@ public class CountryInfoTests
 
         // Act & Assert
 
-        country.Regions.ShouldBeAssignableTo<System.Collections.ObjectModel.ReadOnlyCollection<RegionInfo>>();
+        _ = country.Regions.ShouldBeAssignableTo<System.Collections.ObjectModel.ReadOnlyCollection<RegionInfo>>();
     }
 
     [Fact]

--- a/TIKSN.Framework.Core.Tests/Globalization/CultureFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CultureFactoryTests.cs
@@ -57,7 +57,7 @@ public class CultureFactoryTests
         // Assert
 
         created.ShouldBeTrue();
-        culture.ShouldNotBeNull();
+        _ = culture.ShouldNotBeNull();
         culture.Name.ShouldBe("en-US");
     }
 

--- a/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
@@ -210,7 +210,7 @@ public class CurrencyFactoryTests
         // Assert
 
         created.ShouldBeTrue();
-        currency.ShouldNotBeNull();
+        _ = currency.ShouldNotBeNull();
         currency.ISOCurrencySymbol.ShouldBe("USD");
     }
 
@@ -231,7 +231,7 @@ public class CurrencyFactoryTests
         // Assert
 
         created.ShouldBeTrue();
-        currency.ShouldNotBeNull();
+        _ = currency.ShouldNotBeNull();
         currency.ISOCurrencySymbol.ShouldBe("USD");
     }
 }

--- a/TIKSN.Framework.Core.Tests/Globalization/DateTimeZoneLookupTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/DateTimeZoneLookupTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class DateTimeZoneLookupTests
+{
+    [Fact]
+    public void GivenAliasTimeZone_WhenResolved_ThenCanonicalRegionShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+        var timeZone = DateTimeZoneProviders.Tzdb["US/Eastern"];
+
+        // Act
+
+        var region = lookup.ResolveTimeZoneRegion(timeZone);
+        var country = lookup.ResolveTimeZoneCountry(timeZone);
+
+        // Assert
+
+        region.TwoLetterISORegionName.ShouldBe("US");
+        country.Name.ShouldBe("US");
+    }
+
+    [Fact]
+    public void GivenCanonicalTimeZone_WhenResolved_ThenRegionAndCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+        var timeZone = DateTimeZoneProviders.Tzdb["Asia/Yerevan"];
+
+        // Act
+
+        var region = lookup.ResolveTimeZoneRegion(timeZone);
+        var country = lookup.ResolveTimeZoneCountry(timeZone);
+
+        // Assert
+
+        region.TwoLetterISORegionName.ShouldBe("AM");
+        country.Name.ShouldBe("AM");
+    }
+
+    [Fact]
+    public void GivenCountry_WhenTimeZonesListed_ThenAllRegionalZonesShouldBeReturned()
+    {
+        // Arrange
+
+        var serviceProvider = CreateServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var lookup = serviceProvider.GetRequiredService<IDateTimeZoneLookup>();
+        var unitedStates = countryFactory.Create("US");
+
+        // Act
+
+        var timeZoneIds = lookup.ListCountryTimeZones(unitedStates).Select(x => x.Id).ToArray();
+
+        // Assert
+
+        timeZoneIds.ShouldContain("America/New_York");
+        timeZoneIds.ShouldContain("America/Puerto_Rico");
+        timeZoneIds.ShouldContain("Pacific/Guam");
+    }
+
+    [Fact]
+    public void GivenCountry_WhenTimeZonesListed_ThenResultShouldBeDistinctAndOrdered()
+    {
+        // Arrange
+
+        var serviceProvider = CreateServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var lookup = serviceProvider.GetRequiredService<IDateTimeZoneLookup>();
+        var unitedStates = countryFactory.Create("US");
+
+        // Act
+
+        var timeZoneIds = lookup.ListCountryTimeZones(unitedStates).Select(x => x.Id).ToArray();
+
+        // Assert
+
+        timeZoneIds.Length.ShouldBe(timeZoneIds.Distinct(StringComparer.Ordinal).Count());
+        timeZoneIds.ShouldBe([.. timeZoneIds.OrderBy(x => x, StringComparer.Ordinal)]);
+    }
+
+    [Fact]
+    public void GivenKnownRegions_WhenTimeZonesListed_ThenRegionalZonesShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+
+        // Act
+
+        var unitedStatesZones = lookup.ListRegionalTimeZones(new RegionInfo("US")).Select(x => x.Id).ToArray();
+        var armeniaZones = lookup.ListRegionalTimeZones(new RegionInfo("AM")).Select(x => x.Id).ToArray();
+
+        // Assert
+
+        unitedStatesZones.ShouldContain("America/New_York");
+        armeniaZones.ShouldContain("Asia/Yerevan");
+    }
+
+    [Fact]
+    public void GivenNullInputs_WhenLookupCalled_ThenItShouldThrow()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+        RegionInfo nullRegion = null;
+        CountryInfo nullCountry = null;
+        DateTimeZone nullTimeZone = null;
+
+        // Act & Assert
+
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ListRegionalTimeZones(nullRegion));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ListCountryTimeZones(nullCountry));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ResolveTimeZoneRegion(nullTimeZone));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ResolveTimeZoneCountry(nullTimeZone));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.TryResolveTimeZoneRegion(nullTimeZone, out _));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.TryResolveTimeZoneCountry(nullTimeZone, out _));
+    }
+
+    [Fact]
+    public void GivenTerritoryTimeZone_WhenResolved_ThenTerritoryRegionAndParentCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+        var timeZone = DateTimeZoneProviders.Tzdb["Pacific/Guam"];
+
+        // Act
+
+        var region = lookup.ResolveTimeZoneRegion(timeZone);
+        var country = lookup.ResolveTimeZoneCountry(timeZone);
+
+        // Assert
+
+        region.TwoLetterISORegionName.ShouldBe("GU");
+        country.Name.ShouldBe("US");
+    }
+
+    [Fact]
+    public void GivenUtcTimeZone_WhenResolved_ThenRequiredLookupShouldThrow()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+
+        // Act & Assert
+
+        _ = Should.Throw<DateTimeZoneLookupException>(() => lookup.ResolveTimeZoneRegion(DateTimeZone.Utc));
+        _ = Should.Throw<DateTimeZoneLookupException>(() => lookup.ResolveTimeZoneCountry(DateTimeZone.Utc));
+    }
+
+    [Fact]
+    public void GivenUtcTimeZone_WhenTryResolved_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<IDateTimeZoneLookup>();
+
+        // Act
+
+        var regionResolved = lookup.TryResolveTimeZoneRegion(DateTimeZone.Utc, out var region);
+        var countryResolved = lookup.TryResolveTimeZoneCountry(DateTimeZone.Utc, out var country);
+
+        // Assert
+
+        regionResolved.ShouldBeFalse();
+        region.ShouldBeNull();
+        countryResolved.ShouldBeFalse();
+        country.ShouldBeNull();
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        return services.BuildServiceProvider();
+    }
+}

--- a/TIKSN.Framework.Core.Tests/Globalization/RegionFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/RegionFactoryTests.cs
@@ -57,7 +57,7 @@ public class RegionFactoryTests
         // Assert
 
         created.ShouldBeTrue();
-        region.ShouldNotBeNull();
+        _ = region.ShouldNotBeNull();
         region.TwoLetterISORegionName.ShouldBe("US");
     }
 
@@ -75,7 +75,7 @@ public class RegionFactoryTests
         // Assert
 
         created.ShouldBeTrue();
-        region.ShouldNotBeNull();
+        _ = region.ShouldNotBeNull();
         region.TwoLetterISORegionName.ShouldBe("US");
     }
 

--- a/TIKSN.Framework.Core.Tests/Globalization/TimeZoneInfoLookupTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/TimeZoneInfoLookupTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Globalization;
+
+public class TimeZoneInfoLookupTests
+{
+    [Fact]
+    public void GivenCountry_WhenTimeZonesListed_ThenAllRegionalZonesShouldBeReturned()
+    {
+        // Arrange
+
+        var serviceProvider = CreateServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var lookup = serviceProvider.GetRequiredService<ITimeZoneInfoLookup>();
+        var unitedStates = countryFactory.Create("US");
+
+        // Act
+
+        var timeZoneIds = lookup.ListCountryTimeZones(unitedStates).Select(ToIanaId).ToArray();
+
+        // Assert
+
+        timeZoneIds.ShouldContain("America/New_York");
+        timeZoneIds.ShouldContain("America/Puerto_Rico");
+        timeZoneIds.ShouldContain("Pacific/Guam");
+    }
+
+    [Fact]
+    public void GivenKnownRegions_WhenTimeZonesListed_ThenRegionalZonesShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+
+        // Act
+
+        var unitedStatesZones = lookup.ListRegionalTimeZones(new RegionInfo("US")).Select(ToIanaId).ToArray();
+        var armeniaZones = lookup.ListRegionalTimeZones(new RegionInfo("AM")).Select(ToIanaId).ToArray();
+
+        // Assert
+
+        unitedStatesZones.ShouldContain("America/New_York");
+        armeniaZones.ShouldContain("Asia/Yerevan");
+    }
+
+    [Fact]
+    public void GivenNullInputs_WhenLookupCalled_ThenItShouldThrow()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+        RegionInfo nullRegion = null;
+        CountryInfo nullCountry = null;
+        TimeZoneInfo nullTimeZone = null;
+
+        // Act & Assert
+
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ListRegionalTimeZones(nullRegion));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ListCountryTimeZones(nullCountry));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ResolveTimeZoneRegion(nullTimeZone));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.ResolveTimeZoneCountry(nullTimeZone));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.TryResolveTimeZoneRegion(nullTimeZone, out _));
+        _ = Should.Throw<ArgumentNullException>(() => lookup.TryResolveTimeZoneCountry(nullTimeZone, out _));
+    }
+
+    [Fact]
+    public void GivenTerritoryTimeZoneInfo_WhenResolved_ThenTerritoryRegionAndParentCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+        var timeZone = ResolveTimeZoneInfo("Pacific/Guam");
+
+        // Act
+
+        var region = lookup.ResolveTimeZoneRegion(timeZone);
+        var country = lookup.ResolveTimeZoneCountry(timeZone);
+
+        // Assert
+
+        region.TwoLetterISORegionName.ShouldBe("GU");
+        country.Name.ShouldBe("US");
+    }
+
+    [Fact]
+    public void GivenTimeZoneInfo_WhenResolved_ThenRegionAndCountryShouldBeReturned()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+        var timeZone = ResolveTimeZoneInfo("Asia/Yerevan");
+
+        // Act
+
+        var region = lookup.ResolveTimeZoneRegion(timeZone);
+        var country = lookup.ResolveTimeZoneCountry(timeZone);
+
+        // Assert
+
+        region.TwoLetterISORegionName.ShouldBe("AM");
+        country.Name.ShouldBe("AM");
+    }
+
+    [Fact]
+    public void GivenUtcTimeZoneInfo_WhenResolved_ThenRequiredLookupShouldThrow()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+
+        // Act & Assert
+
+        _ = Should.Throw<DateTimeZoneLookupException>(() => lookup.ResolveTimeZoneRegion(TimeZoneInfo.Utc));
+        _ = Should.Throw<DateTimeZoneLookupException>(() => lookup.ResolveTimeZoneCountry(TimeZoneInfo.Utc));
+    }
+
+    [Fact]
+    public void GivenUtcTimeZoneInfo_WhenTryResolved_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var lookup = CreateServiceProvider().GetRequiredService<ITimeZoneInfoLookup>();
+
+        // Act
+
+        var regionResolved = lookup.TryResolveTimeZoneRegion(TimeZoneInfo.Utc, out var region);
+        var countryResolved = lookup.TryResolveTimeZoneCountry(TimeZoneInfo.Utc, out var country);
+
+        // Assert
+
+        regionResolved.ShouldBeFalse();
+        region.ShouldBeNull();
+        countryResolved.ShouldBeFalse();
+        country.ShouldBeNull();
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        return services.BuildServiceProvider();
+    }
+
+    private static TimeZoneInfo ResolveTimeZoneInfo(string ianaId)
+    {
+        if (TimeZoneInfo.TryFindSystemTimeZoneById(ianaId, out var timeZoneInfo))
+        {
+            return timeZoneInfo;
+        }
+
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(ianaId, out var windowsId) &&
+            TimeZoneInfo.TryFindSystemTimeZoneById(windowsId, out timeZoneInfo))
+        {
+            return timeZoneInfo;
+        }
+
+        throw new InvalidOperationException($"TZDB time zone '{ianaId}' cannot be resolved to TimeZoneInfo.");
+    }
+
+    private static string ToIanaId(TimeZoneInfo timeZoneInfo)
+    {
+        if (DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZoneInfo.Id) is not null)
+        {
+            return timeZoneInfo.Id;
+        }
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneInfo.Id, out var ianaId))
+        {
+            return ianaId;
+        }
+
+        throw new InvalidOperationException($"TimeZoneInfo '{timeZoneInfo.Id}' cannot be resolved to an IANA ID.");
+    }
+}

--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ICultureFactory, CultureFactory>();
         services.TryAddSingleton<ICountryFactory, CountryFactory>();
         services.TryAddSingleton<ICurrencyFactory, CurrencyFactory>();
+        services.TryAddSingleton<IDateTimeZoneLookup, DateTimeZoneLookup>();
         services.TryAddSingleton<IRegionFactory, RegionFactory>();
         services.TryAddSingleton<IResourceNamesCache, ResourceNamesCache>();
         services.TryAddSingleton<IShellCommandEngine, ShellCommandEngine>();

--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ICountryFactory, CountryFactory>();
         services.TryAddSingleton<ICurrencyFactory, CurrencyFactory>();
         services.TryAddSingleton<IDateTimeZoneLookup, DateTimeZoneLookup>();
+        services.TryAddSingleton<ITimeZoneInfoLookup, TimeZoneInfoLookup>();
         services.TryAddSingleton<IRegionFactory, RegionFactory>();
         services.TryAddSingleton<IResourceNamesCache, ResourceNamesCache>();
         services.TryAddSingleton<IShellCommandEngine, ShellCommandEngine>();

--- a/TIKSN.Framework.Core/Globalization/CountryFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/CountryFactory.cs
@@ -99,9 +99,12 @@ public class CountryFactory : MemoryCacheDecoratorBase<CountryInfo>, ICountryFac
             throw new ArgumentNullException(nameof(regionNames), "Country regions cannot be null.");
         }
 
-        return [.. regionNames
-            .Select(NormalizeCode)
-            .Distinct(StringComparer.Ordinal)];
+        return
+        [
+            .. regionNames
+                .Select(NormalizeCode)
+                .Distinct(StringComparer.Ordinal)
+        ];
     }
 
     private static void ValidateConfiguredConcreteRegionCode(string code)

--- a/TIKSN.Framework.Core/Globalization/DateTimeZoneLookup.cs
+++ b/TIKSN.Framework.Core/Globalization/DateTimeZoneLookup.cs
@@ -1,0 +1,163 @@
+using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using LanguageExt;
+using NodaTime;
+using NodaTime.TimeZones;
+
+namespace TIKSN.Globalization;
+
+public class DateTimeZoneLookup : IDateTimeZoneLookup
+{
+    private static readonly TzdbDateTimeZoneSource Source = TzdbDateTimeZoneSource.Default;
+
+    private readonly ICountryFactory countryFactory;
+    private readonly FrozenDictionary<string, Seq<DateTimeZone>> regionCodeToZones;
+    private readonly IRegionFactory regionFactory;
+    private readonly FrozenDictionary<string, string[]> zoneIdToRegionCodes;
+
+    public DateTimeZoneLookup(IRegionFactory regionFactory, ICountryFactory countryFactory)
+    {
+        this.regionFactory = regionFactory ?? throw new ArgumentNullException(nameof(regionFactory));
+        this.countryFactory = countryFactory ?? throw new ArgumentNullException(nameof(countryFactory));
+        this.regionCodeToZones = BuildRegionCodeToZones();
+        this.zoneIdToRegionCodes = BuildZoneIdToRegionCodes();
+    }
+
+    public Seq<DateTimeZone> ListCountryTimeZones(CountryInfo country)
+    {
+        ArgumentNullException.ThrowIfNull(country);
+
+        return country.Regions
+            .SelectMany(region => this.ListRegionalTimeZones(region))
+            .DistinctBy(timeZone => timeZone.Id)
+            .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+            .ToSeq();
+    }
+
+    public Seq<DateTimeZone> ListRegionalTimeZones(RegionInfo region)
+    {
+        ArgumentNullException.ThrowIfNull(region);
+
+        return this.regionCodeToZones.TryGetValue(region.TwoLetterISORegionName, out var zones)
+            ? zones
+            : Enumerable.Empty<DateTimeZone>().ToSeq();
+    }
+
+    public CountryInfo ResolveTimeZoneCountry(DateTimeZone timeZone)
+    {
+        var region = this.ResolveTimeZoneRegion(timeZone);
+
+        return this.countryFactory.Create(region);
+    }
+
+    public RegionInfo ResolveTimeZoneRegion(DateTimeZone timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        var canonicalZoneId = NormalizeZoneId(timeZone.Id);
+
+        if (!this.zoneIdToRegionCodes.TryGetValue(canonicalZoneId, out var regionCodes))
+        {
+            throw new DateTimeZoneLookupException($"Time zone '{timeZone.Id}' does not have a regional TZDB location.");
+        }
+
+        if (regionCodes.Length != 1)
+        {
+            throw new DateTimeZoneLookupException(
+                $"Time zone '{timeZone.Id}' resolves to multiple regions: {string.Join(", ", regionCodes)}.");
+        }
+
+        return this.regionFactory.Create(regionCodes[0]);
+    }
+
+    public bool TryResolveTimeZoneCountry(DateTimeZone timeZone, [NotNullWhen(true)] out CountryInfo? country)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        try
+        {
+            country = this.ResolveTimeZoneCountry(timeZone);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            country = null;
+            return false;
+        }
+        catch (CountryNotFoundException)
+        {
+            country = null;
+            return false;
+        }
+        catch (DateTimeZoneLookupException)
+        {
+            country = null;
+            return false;
+        }
+    }
+
+    public bool TryResolveTimeZoneRegion(DateTimeZone timeZone, [NotNullWhen(true)] out RegionInfo? region)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        try
+        {
+            region = this.ResolveTimeZoneRegion(timeZone);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            region = null;
+            return false;
+        }
+        catch (DateTimeZoneLookupException)
+        {
+            region = null;
+            return false;
+        }
+    }
+
+    private static FrozenDictionary<string, Seq<DateTimeZone>> BuildRegionCodeToZones() => GetZoneLocations()
+            .GroupBy(location => NormalizeRegionCode(location.CountryCode), StringComparer.Ordinal)
+            .ToFrozenDictionary(
+                group => group.Key,
+                group => group
+                    .Select(location => DateTimeZoneProviders.Tzdb[NormalizeZoneId(location.ZoneId)])
+                    .DistinctBy(timeZone => timeZone.Id)
+                    .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+                    .ToSeq(),
+                StringComparer.Ordinal);
+
+    private static FrozenDictionary<string, string[]> BuildZoneIdToRegionCodes() => GetZoneLocations()
+            .Where(location =>
+                string.Equals(location.ZoneId, NormalizeZoneId(location.ZoneId), StringComparison.Ordinal))
+            .GroupBy(location => location.ZoneId, StringComparer.Ordinal)
+            .ToFrozenDictionary(
+                group => group.Key,
+                group => group
+                    .Select(location => NormalizeRegionCode(location.CountryCode))
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(regionCode => regionCode, StringComparer.Ordinal)
+                    .ToArray(),
+                StringComparer.Ordinal);
+
+    private static IEnumerable<TzdbZoneLocation> GetZoneLocations() =>
+        Source.ZoneLocations ?? Enumerable.Empty<TzdbZoneLocation>();
+
+    private static string NormalizeRegionCode(string regionCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(regionCode);
+
+        return regionCode.Trim().ToUpperInvariant();
+    }
+
+    private static string NormalizeZoneId(string zoneId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(zoneId);
+
+        return Source.CanonicalIdMap.TryGetValue(zoneId, out var canonicalZoneId)
+            ? canonicalZoneId
+            : zoneId;
+    }
+}

--- a/TIKSN.Framework.Core/Globalization/DateTimeZoneLookup.cs
+++ b/TIKSN.Framework.Core/Globalization/DateTimeZoneLookup.cs
@@ -119,28 +119,28 @@ public class DateTimeZoneLookup : IDateTimeZoneLookup
     }
 
     private static FrozenDictionary<string, Seq<DateTimeZone>> BuildRegionCodeToZones() => GetZoneLocations()
-            .GroupBy(location => NormalizeRegionCode(location.CountryCode), StringComparer.Ordinal)
-            .ToFrozenDictionary(
-                group => group.Key,
-                group => group
-                    .Select(location => DateTimeZoneProviders.Tzdb[NormalizeZoneId(location.ZoneId)])
-                    .DistinctBy(timeZone => timeZone.Id)
-                    .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
-                    .ToSeq(),
-                StringComparer.Ordinal);
+        .GroupBy(location => NormalizeRegionCode(location.CountryCode), StringComparer.Ordinal)
+        .ToFrozenDictionary(
+            group => group.Key,
+            group => group
+                .Select(location => DateTimeZoneProviders.Tzdb[NormalizeZoneId(location.ZoneId)])
+                .DistinctBy(timeZone => timeZone.Id)
+                .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+                .ToSeq(),
+            StringComparer.Ordinal);
 
     private static FrozenDictionary<string, string[]> BuildZoneIdToRegionCodes() => GetZoneLocations()
-            .Where(location =>
-                string.Equals(location.ZoneId, NormalizeZoneId(location.ZoneId), StringComparison.Ordinal))
-            .GroupBy(location => location.ZoneId, StringComparer.Ordinal)
-            .ToFrozenDictionary(
-                group => group.Key,
-                group => group
-                    .Select(location => NormalizeRegionCode(location.CountryCode))
-                    .Distinct(StringComparer.Ordinal)
-                    .OrderBy(regionCode => regionCode, StringComparer.Ordinal)
-                    .ToArray(),
-                StringComparer.Ordinal);
+        .Where(location =>
+            string.Equals(location.ZoneId, NormalizeZoneId(location.ZoneId), StringComparison.Ordinal))
+        .GroupBy(location => location.ZoneId, StringComparer.Ordinal)
+        .ToFrozenDictionary(
+            group => group.Key,
+            group => group
+                .Select(location => NormalizeRegionCode(location.CountryCode))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(regionCode => regionCode, StringComparer.Ordinal)
+                .ToArray(),
+            StringComparer.Ordinal);
 
     private static IEnumerable<TzdbZoneLocation> GetZoneLocations() =>
         Source.ZoneLocations ?? Enumerable.Empty<TzdbZoneLocation>();

--- a/TIKSN.Framework.Core/Globalization/DateTimeZoneLookupException.cs
+++ b/TIKSN.Framework.Core/Globalization/DateTimeZoneLookupException.cs
@@ -1,0 +1,16 @@
+namespace TIKSN.Globalization;
+
+public class DateTimeZoneLookupException : Exception
+{
+    public DateTimeZoneLookupException()
+    {
+    }
+
+    public DateTimeZoneLookupException(string message) : base(message)
+    {
+    }
+
+    public DateTimeZoneLookupException(string message, Exception inner) : base(message, inner)
+    {
+    }
+}

--- a/TIKSN.Framework.Core/Globalization/IDateTimeZoneLookup.cs
+++ b/TIKSN.Framework.Core/Globalization/IDateTimeZoneLookup.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using LanguageExt;
+using NodaTime;
+
+namespace TIKSN.Globalization;
+
+public interface IDateTimeZoneLookup
+{
+    public Seq<DateTimeZone> ListRegionalTimeZones(RegionInfo region);
+
+    public Seq<DateTimeZone> ListCountryTimeZones(CountryInfo country);
+
+    public RegionInfo ResolveTimeZoneRegion(DateTimeZone timeZone);
+
+    public CountryInfo ResolveTimeZoneCountry(DateTimeZone timeZone);
+
+    public bool TryResolveTimeZoneRegion(DateTimeZone timeZone, [NotNullWhen(true)] out RegionInfo? region);
+
+    public bool TryResolveTimeZoneCountry(DateTimeZone timeZone, [NotNullWhen(true)] out CountryInfo? country);
+}

--- a/TIKSN.Framework.Core/Globalization/ITimeZoneInfoLookup.cs
+++ b/TIKSN.Framework.Core/Globalization/ITimeZoneInfoLookup.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using LanguageExt;
+
+namespace TIKSN.Globalization;
+
+public interface ITimeZoneInfoLookup
+{
+    public Seq<TimeZoneInfo> ListRegionalTimeZones(RegionInfo region);
+
+    public Seq<TimeZoneInfo> ListCountryTimeZones(CountryInfo country);
+
+    public RegionInfo ResolveTimeZoneRegion(TimeZoneInfo timeZone);
+
+    public CountryInfo ResolveTimeZoneCountry(TimeZoneInfo timeZone);
+
+    public bool TryResolveTimeZoneRegion(TimeZoneInfo timeZone, [NotNullWhen(true)] out RegionInfo? region);
+
+    public bool TryResolveTimeZoneCountry(TimeZoneInfo timeZone, [NotNullWhen(true)] out CountryInfo? country);
+}

--- a/TIKSN.Framework.Core/Globalization/TimeZoneInfoLookup.cs
+++ b/TIKSN.Framework.Core/Globalization/TimeZoneInfoLookup.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using LanguageExt;
+using NodaTime;
+
+namespace TIKSN.Globalization;
+
+public class TimeZoneInfoLookup : ITimeZoneInfoLookup
+{
+    private readonly IDateTimeZoneLookup dateTimeZoneLookup;
+
+    public TimeZoneInfoLookup(IDateTimeZoneLookup dateTimeZoneLookup)
+        => this.dateTimeZoneLookup = dateTimeZoneLookup ?? throw new ArgumentNullException(nameof(dateTimeZoneLookup));
+
+    public Seq<TimeZoneInfo> ListCountryTimeZones(CountryInfo country)
+    {
+        ArgumentNullException.ThrowIfNull(country);
+
+        return this.dateTimeZoneLookup.ListCountryTimeZones(country)
+            .Select(ResolveTimeZoneInfo)
+            .DistinctBy(timeZone => timeZone.Id)
+            .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+            .ToSeq();
+    }
+
+    public Seq<TimeZoneInfo> ListRegionalTimeZones(RegionInfo region)
+    {
+        ArgumentNullException.ThrowIfNull(region);
+
+        return this.dateTimeZoneLookup.ListRegionalTimeZones(region)
+            .Select(ResolveTimeZoneInfo)
+            .DistinctBy(timeZone => timeZone.Id)
+            .OrderBy(timeZone => timeZone.Id, StringComparer.Ordinal)
+            .ToSeq();
+    }
+
+    public CountryInfo ResolveTimeZoneCountry(TimeZoneInfo timeZone)
+    {
+        var dateTimeZone = ResolveDateTimeZone(timeZone);
+
+        return this.dateTimeZoneLookup.ResolveTimeZoneCountry(dateTimeZone);
+    }
+
+    public RegionInfo ResolveTimeZoneRegion(TimeZoneInfo timeZone)
+    {
+        var dateTimeZone = ResolveDateTimeZone(timeZone);
+
+        return this.dateTimeZoneLookup.ResolveTimeZoneRegion(dateTimeZone);
+    }
+
+    public bool TryResolveTimeZoneCountry(TimeZoneInfo timeZone, [NotNullWhen(true)] out CountryInfo? country)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        try
+        {
+            country = this.ResolveTimeZoneCountry(timeZone);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            country = null;
+            return false;
+        }
+        catch (CountryNotFoundException)
+        {
+            country = null;
+            return false;
+        }
+        catch (DateTimeZoneLookupException)
+        {
+            country = null;
+            return false;
+        }
+    }
+
+    public bool TryResolveTimeZoneRegion(TimeZoneInfo timeZone, [NotNullWhen(true)] out RegionInfo? region)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        try
+        {
+            region = this.ResolveTimeZoneRegion(timeZone);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            region = null;
+            return false;
+        }
+        catch (DateTimeZoneLookupException)
+        {
+            region = null;
+            return false;
+        }
+    }
+
+    private static DateTimeZone ResolveDateTimeZone(TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        var dateTimeZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(timeZone.Id);
+        if (dateTimeZone is not null)
+        {
+            return dateTimeZone;
+        }
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZone.Id, out var ianaId))
+        {
+            dateTimeZone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(ianaId);
+            if (dateTimeZone is not null)
+            {
+                return dateTimeZone;
+            }
+        }
+
+        throw new DateTimeZoneLookupException($"Time zone '{timeZone.Id}' cannot be resolved to a TZDB time zone.");
+    }
+
+    private static TimeZoneInfo ResolveTimeZoneInfo(DateTimeZone dateTimeZone)
+    {
+        ArgumentNullException.ThrowIfNull(dateTimeZone);
+
+        if (TimeZoneInfo.TryFindSystemTimeZoneById(dateTimeZone.Id, out var timeZoneInfo))
+        {
+            return timeZoneInfo;
+        }
+
+        if (TimeZoneInfo.TryConvertIanaIdToWindowsId(dateTimeZone.Id, out var windowsId) &&
+            TimeZoneInfo.TryFindSystemTimeZoneById(windowsId, out timeZoneInfo))
+        {
+            return timeZoneInfo;
+        }
+
+        throw new DateTimeZoneLookupException(
+            $"TZDB time zone '{dateTimeZone.Id}' cannot be resolved to a system TimeZoneInfo.");
+    }
+}


### PR DESCRIPTION
## Summary
- Added a `TimeZoneInfo` sibling lookup service that reuses the TZDB/NodaTime-backed geography lookup as its source of truth.
- Preserves `RegionInfo` and `CountryInfo` coverage through the existing `IDateTimeZoneLookup`, while translating to and from `TimeZoneInfo` at the boundary.
- Registered the new service in DI and added tests for forward lookup, reverse lookup, territory handling, UTC failure behavior, and null guards.

## Testing
- Added focused unit tests for `ITimeZoneInfoLookup` and updated DI registration coverage.
- Verified with `dotnet test .\TIKSN.Framework.Core.Tests\TIKSN.Framework.Core.Tests.csproj --no-restore`.