### PR TITLE
Fix QueryRepositoryPagination integration test failures

### DIFF
--- a/TIKSN.Framework.Core/Data/EntityFrameworkCore/EntityQueryRepository.cs
+++ b/TIKSN.Framework.Core/Data/EntityFrameworkCore/EntityQueryRepository.cs
@@ -46,7 +46,7 @@ public abstract class EntityQueryRepository<TContext, TEntity, TIdentity> : Enti
 
     public async IAsyncEnumerable<TEntity> StreamAllAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var entity in this.Entities.AsAsyncEnumerable().WithCancellation(cancellationToken)
+        await foreach (var entity in this.OrderedEntities.AsAsyncEnumerable().WithCancellation(cancellationToken)
                            .ConfigureAwait(false))
         {
             yield return entity;

--- a/TIKSN.Framework.Core/Data/LiteDB/LiteDbRepository.cs
+++ b/TIKSN.Framework.Core/Data/LiteDB/LiteDbRepository.cs
@@ -101,7 +101,7 @@ public class LiteDbRepository<TDocument, TIdentity> : ILiteDbRepository<TDocumen
     }
 
     public IAsyncEnumerable<TDocument> StreamAllAsync(CancellationToken cancellationToken) =>
-        this.Collection.FindAll().ToAsyncEnumerable();
+        this.Collection.Find(this.PageQuery).ToAsyncEnumerable();
 
     public Task UpdateAsync(TDocument entity, CancellationToken cancellationToken)
     {

--- a/TIKSN.Framework.Core/Data/Mongo/MongoRepository.cs
+++ b/TIKSN.Framework.Core/Data/Mongo/MongoRepository.cs
@@ -158,10 +158,13 @@ public abstract class MongoRepository<TDocument, TIdentity> :
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Task<IAsyncCursor<TDocument>> NoneAsync() =>
-            this.Collection.Find(FilterDefinition<TDocument>.Empty).ToCursorAsync(cancellationToken);
+            this.Collection.Find(FilterDefinition<TDocument>.Empty)
+                .Sort(this.PageSortDefinition)
+                .ToCursorAsync(cancellationToken);
 
         Task<IAsyncCursor<TDocument>> SomeAsync(IClientSessionHandle clientSessionHandle) => this.Collection
             .Find(clientSessionHandle, FilterDefinition<TDocument>.Empty)
+            .Sort(this.PageSortDefinition)
             .ToCursorAsync(cancellationToken);
 
         var cursor = await this.MongoClientSessionProvider.GetClientSessionHandle().Match(SomeAsync, NoneAsync)

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Data/EntityFrameworkCore/ExchangeRateDataRepository.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Data/EntityFrameworkCore/ExchangeRateDataRepository.cs
@@ -12,7 +12,12 @@ public class ExchangeRateDataRepository :
     }
 
     protected override IOrderedQueryable<ExchangeRateDataEntity> OrderedEntities
-        => this.Entities.OrderBy(x => x.AsOn);
+        => this.Entities
+            .OrderBy(x => x.AsOn)
+            .ThenBy(x => x.BaseCurrencyCode)
+            .ThenBy(x => x.CounterCurrencyCode)
+            .ThenBy(x => x.ForeignExchangeID)
+            .ThenBy(x => x.ID);
 
     public async Task<IReadOnlyList<ExchangeRateDataEntity>> SearchAsync(
         Guid foreignExchangeID,

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Data/Mongo/ExchangeRateDataRepository.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Data/Mongo/ExchangeRateDataRepository.cs
@@ -16,7 +16,12 @@ public class ExchangeRateDataRepository : MongoRepository<ExchangeRateDataEntity
     }
 
     protected override SortDefinition<ExchangeRateDataEntity> PageSortDefinition
-        => Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.AsOn);
+        => Builders<ExchangeRateDataEntity>.Sort.Combine(
+            Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.AsOn),
+            Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.BaseCurrencyCode),
+            Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.CounterCurrencyCode),
+            Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.ForeignExchangeID),
+            Builders<ExchangeRateDataEntity>.Sort.Ascending(x => x.ID));
 
     public Task<IReadOnlyList<ExchangeRateDataEntity>> SearchAsync(
         string baseCurrencyCode,


### PR DESCRIPTION
## Summary
- Materialize mapped page items as `List<T>` instead of compiler-generated read-only collections.
- Align `StreamAllAsync()` ordering with paged-query ordering across EF, MongoDB, and LiteDB.
- Add stable tie-breakers to exchange-rate pagination so equal `AsOn` values sort deterministically.

## Testing
- Focused integration tests for `QueryRepositoryPaginationTests` passed across LiteDB, MongoDB, and SQLite.
- Verified the paging regression is resolved without changing the public repository contracts.