### PR TITLE
Update Bank of Russia currency-pair expectations

### DIFF
--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
@@ -153,7 +153,6 @@ public class BankOfRussiaTests
         pairs.ShouldContain(c => c.ToString() == "AZN/RUB");
         pairs.ShouldContain(c => c.ToString() == "AMD/RUB");
         pairs.ShouldContain(c => c.ToString() == "BYN/RUB");
-        pairs.ShouldContain(c => c.ToString() == "BGN/RUB");
         pairs.ShouldContain(c => c.ToString() == "BRL/RUB");
         pairs.ShouldContain(c => c.ToString() == "HUF/RUB");
         pairs.ShouldContain(c => c.ToString() == "KRW/RUB");
@@ -186,7 +185,6 @@ public class BankOfRussiaTests
         pairs.ShouldContain(c => c.ToString() == "RUB/AZN");
         pairs.ShouldContain(c => c.ToString() == "RUB/AMD");
         pairs.ShouldContain(c => c.ToString() == "RUB/BYN");
-        pairs.ShouldContain(c => c.ToString() == "RUB/BGN");
         pairs.ShouldContain(c => c.ToString() == "RUB/BRL");
         pairs.ShouldContain(c => c.ToString() == "RUB/HUF");
         pairs.ShouldContain(c => c.ToString() == "RUB/KRW");


### PR DESCRIPTION
## Summary
- Remove stale `BGN/RUB` and `RUB/BGN` assertions from the Bank of Russia integration test so it matches the current CBR feed.
- Preserve the live XML comparison coverage for current and historical currency pairs.
- Apply minor formatting cleanup in `EnvironmentName` and `RavenDatabaseInitializer`.

## Testing
- Targeted `BankOfRussiaTests.GetCurrencyPairs004` integration test passed locally.
- Existing build and analyzer warnings remain unchanged.