### PR TITLE
Refresh currency codes before restore and build

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -134,7 +134,7 @@ Task RestorePackages Clean, EnsureCentralPackageVersions, {
 }
 
 # Synopsis: Restore
-Task Restore RestoreWorkloads, RestoreTools, RestorePackages
+Task Restore RestoreWorkloads, RestoreTools, RestorePackages, DownloadCurrencyCodes
 
 # Synopsis: Download Currency Codes
 Task DownloadCurrencyCodes Clean, {
@@ -332,7 +332,7 @@ Task BuildRegionLocalization EstimateVersion, {
 }
 
 # Synopsis: Build Core
-Task BuildCore EstimateVersion, {
+Task BuildCore EstimateVersion, DownloadCurrencyCodes, {
     $state = Import-Clixml -Path ".\.trash\$Instance\state.clixml"
     $anyBuildArtifactsFolder = $state.AnyBuildArtifactsFolder
     $project = Resolve-Path -Path 'TIKSN.Framework.Core/TIKSN.Framework.Core.csproj'
@@ -361,7 +361,7 @@ Task BuildMaui EstimateVersion, {
 }
 
 # Synopsis: Build
-Task Build Format, BuildLanguageLocalization, BuildRegionLocalization, BuildCore, BuildMaui, {
+Task Build Format, DownloadCurrencyCodes, BuildLanguageLocalization, BuildRegionLocalization, BuildCore, BuildMaui, {
     $solution = Resolve-Path -Path 'TIKSN Framework.slnx'
     Exec { dotnet build $solution }
 }

--- a/TIKSN.Framework.Core/Finance/Resources/TableA1.xml
+++ b/TIKSN.Framework.Core/Finance/Resources/TableA1.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-01-01">
+<ISO_4217 Pblshd="2026-01-01">
   <CcyTbl>
     <CcyNtry>
       <CtryNm>AFGHANISTAN</CtryNm>
@@ -66,6 +66,13 @@
       <CcyNm>East Caribbean Dollar</CcyNm>
       <Ccy>XCD</Ccy>
       <CcyNbr>951</CcyNbr>
+      <CcyMnrUnts>2</CcyMnrUnts>
+    </CcyNtry>
+    <CcyNtry>
+      <CtryNm>ARAB MONETARY FUND</CtryNm>
+      <CcyNm>Arab Accounting Dinar</CcyNm>
+      <Ccy>XAD</Ccy>
+      <CcyNbr>396</CcyNbr>
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
     <CcyNtry>
@@ -252,9 +259,9 @@
     </CcyNtry>
     <CcyNtry>
       <CtryNm>BULGARIA</CtryNm>
-      <CcyNm>Bulgarian Lev</CcyNm>
-      <Ccy>BGN</Ccy>
-      <CcyNbr>975</CcyNbr>
+      <CcyNm>Euro</CcyNm>
+      <Ccy>EUR</Ccy>
+      <CcyNbr>978</CcyNbr>
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
     <CcyNtry>
@@ -426,16 +433,9 @@
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
     <CcyNtry>
-      <CtryNm>CUBA</CtryNm>
-      <CcyNm>Peso Convertible</CcyNm>
-      <Ccy>CUC</Ccy>
-      <CcyNbr>931</CcyNbr>
-      <CcyMnrUnts>2</CcyMnrUnts>
-    </CcyNtry>
-    <CcyNtry>
       <CtryNm>CURAÇAO</CtryNm>
-      <CcyNm>Netherlands Antillean Guilder</CcyNm>
-      <Ccy>ANG</Ccy>
+      <CcyNm>Caribbean Guilder</CcyNm>
+      <Ccy>XCG</Ccy>
       <CcyNbr>532</CcyNbr>
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
@@ -1502,8 +1502,8 @@
     </CcyNtry>
     <CcyNtry>
       <CtryNm>SINT MAARTEN (DUTCH PART)</CtryNm>
-      <CcyNm>Netherlands Antillean Guilder</CcyNm>
-      <Ccy>ANG</Ccy>
+      <CcyNm>Caribbean Guilder</CcyNm>
+      <Ccy>XCG</Ccy>
       <CcyNbr>532</CcyNbr>
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
@@ -1877,9 +1877,9 @@
     </CcyNtry>
     <CcyNtry>
       <CtryNm>ZIMBABWE</CtryNm>
-      <CcyNm>Zimbabwe Dollar</CcyNm>
-      <Ccy>ZWL</Ccy>
-      <CcyNbr>932</CcyNbr>
+      <CcyNm>Zimbabwe Gold</CcyNm>
+      <Ccy>ZWG</Ccy>
+      <CcyNbr>924</CcyNbr>
       <CcyMnrUnts>2</CcyMnrUnts>
     </CcyNtry>
     <CcyNtry>

--- a/TIKSN.Framework.Core/Finance/Resources/TableA3.xml
+++ b/TIKSN.Framework.Core/Finance/Resources/TableA3.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ISO_4217 Pblshd="2024-01-01">
+<ISO_4217 Pblshd="2026-01-01">
   <HstrcCcyTbl>
     <HstrcCcyNtry>
       <CtryNm>AFGHANISTAN</CtryNm>
@@ -233,6 +233,13 @@
       <WthdrwlDt>2003-11</WthdrwlDt>
     </HstrcCcyNtry>
     <HstrcCcyNtry>
+      <CtryNm>BULGARIA</CtryNm>
+      <CcyNm>Bulgarian Lev</CcyNm>
+      <Ccy>BGN</Ccy>
+      <CcyNbr>975</CcyNbr>
+      <WthdrwlDt>2026-01</WthdrwlDt>
+    </HstrcCcyNtry>
+    <HstrcCcyNtry>
       <CtryNm>BURMA </CtryNm>
       <CcyNm>Kyat</CcyNm>
       <Ccy>BUK</Ccy>
@@ -259,6 +266,20 @@
       <Ccy>HRK</Ccy>
       <CcyNbr>191</CcyNbr>
       <WthdrwlDt>2023-01</WthdrwlDt>
+    </HstrcCcyNtry>
+    <HstrcCcyNtry>
+      <CtryNm>CUBA</CtryNm>
+      <CcyNm>Peso Convertible</CcyNm>
+      <Ccy>CUC</Ccy>
+      <CcyNbr>931</CcyNbr>
+      <WthdrwlDt>2021-06</WthdrwlDt>
+    </HstrcCcyNtry>
+    <HstrcCcyNtry>
+      <CtryNm>CURAÇAO</CtryNm>
+      <CcyNm>Netherlands Antillean Guilder</CcyNm>
+      <Ccy>ANG</Ccy>
+      <CcyNbr>532</CcyNbr>
+      <WthdrwlDt>2025-03</WthdrwlDt>
     </HstrcCcyNtry>
     <HstrcCcyNtry>
       <CtryNm>CYPRUS</CtryNm>
@@ -807,6 +828,13 @@
       <WthdrwlDt>2023-12</WthdrwlDt>
     </HstrcCcyNtry>
     <HstrcCcyNtry>
+      <CtryNm>SINT MAARTEN (DUTCH PART)</CtryNm>
+      <CcyNm>Netherlands Antillean Guilder</CcyNm>
+      <Ccy>ANG</Ccy>
+      <CcyNbr>532</CcyNbr>
+      <WthdrwlDt>2025-03</WthdrwlDt>
+    </HstrcCcyNtry>
+    <HstrcCcyNtry>
       <CtryNm>SLOVAKIA</CtryNm>
       <CcyNm>Slovak Koruna</CcyNm>
       <Ccy>SKK</Ccy>
@@ -1127,6 +1155,13 @@
       <Ccy>ZWR</Ccy>
       <CcyNbr>935</CcyNbr>
       <WthdrwlDt>2009-06</WthdrwlDt>
+    </HstrcCcyNtry>
+    <HstrcCcyNtry>
+      <CtryNm>ZIMBABWE</CtryNm>
+      <CcyNm>Zimbabwe Dollar</CcyNm>
+      <Ccy>ZWL</Ccy>
+      <CcyNbr>932</CcyNbr>
+      <WthdrwlDt>2024-09</WthdrwlDt>
     </HstrcCcyNtry>
     <HstrcCcyNtry>
       <CtryNm>ZZ01_Gold-Franc</CtryNm>


### PR DESCRIPTION
## Summary
- Wire `DownloadCurrencyCodes` into `Restore`, `BuildCore`, and `Build` so the SIX ISO 4217 XML is refreshed before core compilation and test/build entrypoints run.
- Keep the fetched currency resources as generated inputs rather than hand-editing the XML files.
- This resolves the National Bank of Poland integration failures caused by stale currency data, including missing `XCG`.

## Testing
- `.estore.ps1` passed and showed `DownloadCurrencyCodes` running as part of the restore flow.
- `.uild.ps1` passed and refreshed the currency resources before compiling.
- Focused `CurrencyInfoTests` passed.
- Focused `NationalBankOfPolandTests` passed.