### PR TITLE
Fix ECB integration tests and align date handling with ECB timezone

### DIFF
--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -81,7 +81,10 @@ public static class ServiceCollectionExtensions
             .ConfigureHttpClient(config =>
                 config.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TIKSN-Framework",
                     typeof(ServiceCollectionExtensions).Assembly.GetName().Version?.ToString())));
-        _ = services.AddHttpClient<IEuropeanCentralBank, EuropeanCentralBank>();
+        _ = services.AddHttpClient<IEuropeanCentralBank, EuropeanCentralBank>()
+            .ConfigureHttpClient(config =>
+                config.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TIKSN-Framework",
+                    typeof(ServiceCollectionExtensions).Assembly.GetName().Version?.ToString())));
         _ = services.AddHttpClient<IFederalReserveSystem, FederalReserveSystem>();
         _ = services.AddHttpClient<INationalBankOfPoland, NationalBankOfPoland>();
         _ = services.AddHttpClient<INationalBankOfUkraine, NationalBankOfUkraine>();

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Xml.Linq;
 using TIKSN.Globalization;
@@ -6,15 +7,18 @@ namespace TIKSN.Finance.ForeignExchange.Bank;
 
 public class EuropeanCentralBank : IEuropeanCentralBank
 {
+    private static readonly TimeZoneInfo EuropeanCentralBankTimeZone = CreateEuropeanCentralBankTimeZone();
     private static readonly Uri DailyRatesUrl = new("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml");
 
     private static readonly CurrencyInfo Euro = new(new RegionInfo("de-DE"));
+
 
     private static readonly Uri Last90DaysRatesUrl =
         new("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml");
 
     private static readonly Uri Since1999RatesUrl = new("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml");
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ConcurrentDictionary<(Uri RequestURL, DateOnly RequestDate), XDocument> exchangeRateDocuments = [];
     private readonly HttpClient httpClient;
     private readonly TimeProvider timeProvider;
 
@@ -94,20 +98,19 @@ public class EuropeanCentralBank : IEuropeanCentralBank
     {
         var requestURL = GetRatesUrl(asOn, this.timeProvider);
 
-        var responseStream = await this.httpClient.GetStreamAsync(requestURL, cancellationToken).ConfigureAwait(false);
-
-        var xdoc = XDocument.Load(responseStream);
+        var xdoc = await this.GetExchangeRateDocumentAsync(requestURL, cancellationToken).ConfigureAwait(false);
 
         var groupsCubes = xdoc
             ?.Element("{http://www.gesmes.org/xml/2002-08-01}Envelope")
             ?.Element("{http://www.ecb.int/vocabulary/2002-08-01/eurofxref}Cube")
             ?.Elements("{http://www.ecb.int/vocabulary/2002-08-01/eurofxref}Cube") ?? [];
 
+        var asOnDate = GetCentralEuropeanDate(asOn);
         var groupCubes = groupsCubes
             .Select(x =>
-                new Tuple<XElement, DateTimeOffset>(x,
-                    DateTimeOffset.Parse(x?.Attribute("time")?.Value ?? string.Empty, CultureInfo.InvariantCulture)))
-            .Where(z => z.Item2 <= asOn)
+                new Tuple<XElement, DateOnly>(x,
+                    DateOnly.Parse(x?.Attribute("time")?.Value ?? string.Empty, CultureInfo.InvariantCulture)))
+            .Where(z => z.Item2 <= asOnDate)
             .OrderByDescending(y => y.Item2)
             .Select(x => (x.Item1, x.Item2))
             .First();
@@ -121,25 +124,73 @@ public class EuropeanCentralBank : IEuropeanCentralBank
             var rate = decimal.Parse(rateCube?.Attribute("rate")?.Value ?? string.Empty, CultureInfo.InvariantCulture);
 
             rates.Add(new ExchangeRate(new CurrencyPair(Euro, this.currencyFactory.Create(currencyCode)),
-                groupCubes.Item2, rate));
+                CreateEuropeanCentralBankDateTimeOffset(groupCubes.Item2), rate));
         }
 
         return rates;
     }
 
+    private static DateTimeOffset CreateEuropeanCentralBankDateTimeOffset(DateOnly date)
+    {
+        var localDateTime = date.ToDateTime(TimeOnly.MinValue);
+
+        return new DateTimeOffset(localDateTime, EuropeanCentralBankTimeZone.GetUtcOffset(localDateTime));
+    }
+
+    private static TimeZoneInfo CreateEuropeanCentralBankTimeZone()
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("Europe/Frankfurt");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+        }
+    }
+
+    private static DateOnly GetCentralEuropeanDate(DateTimeOffset dateTime) =>
+        DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(dateTime, EuropeanCentralBankTimeZone).DateTime);
+
     private static Uri GetRatesUrl(DateTimeOffset asOn, TimeProvider timeProvider)
     {
-        if (asOn.Date == timeProvider.GetUtcNow().Date)
+        var asOnDate = GetCentralEuropeanDate(asOn);
+        var today = GetCentralEuropeanDate(timeProvider.GetUtcNow());
+
+        if (asOnDate == today)
         {
             return DailyRatesUrl;
         }
 
-        if (asOn.Date >= timeProvider.GetUtcNow().AddDays(-90).Date)
+        if (asOnDate >= today.AddDays(-90))
         {
             return Last90DaysRatesUrl;
         }
 
         return Since1999RatesUrl;
+    }
+
+    private async Task<XDocument> GetExchangeRateDocumentAsync(Uri requestURL, CancellationToken cancellationToken)
+    {
+        var cacheKey = (requestURL, GetCentralEuropeanDate(this.timeProvider.GetUtcNow()));
+
+        if (this.exchangeRateDocuments.TryGetValue(cacheKey, out var cachedDocument))
+        {
+            return cachedDocument;
+        }
+
+        var responseStream = await this.httpClient.GetStreamAsync(requestURL, cancellationToken).ConfigureAwait(false);
+
+        await using (responseStream.ConfigureAwait(false))
+        {
+            var document = XDocument.Load(responseStream);
+
+            return this.exchangeRateDocuments.GetOrAdd(cacheKey, document);
+        }
     }
 
     private void VerifyDate(DateTimeOffset asOn)

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/EuropeanCentralBankTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/EuropeanCentralBankTests.cs
@@ -177,7 +177,6 @@ public class EuropeanCentralBankTests
             cancellationToken: TestContext.Current.CancellationToken);
 
         pairs.ShouldContain(p => p.ToString() == "AUD/EUR");
-        pairs.ShouldContain(p => p.ToString() == "BGN/EUR");
         pairs.ShouldContain(p => p.ToString() == "BRL/EUR");
         pairs.ShouldContain(p => p.ToString() == "CAD/EUR");
         pairs.ShouldContain(p => p.ToString() == "CHF/EUR");
@@ -190,6 +189,7 @@ public class EuropeanCentralBankTests
         pairs.ShouldContain(p => p.ToString() == "IDR/EUR");
         pairs.ShouldContain(p => p.ToString() == "ILS/EUR");
         pairs.ShouldContain(p => p.ToString() == "INR/EUR");
+        pairs.ShouldContain(p => p.ToString() == "ISK/EUR");
         pairs.ShouldContain(p => p.ToString() == "JPY/EUR");
         pairs.ShouldContain(p => p.ToString() == "KRW/EUR");
         pairs.ShouldContain(p => p.ToString() == "MXN/EUR");
@@ -207,7 +207,6 @@ public class EuropeanCentralBankTests
         pairs.ShouldContain(p => p.ToString() == "ZAR/EUR");
 
         pairs.ShouldContain(p => p.ToString() == "EUR/AUD");
-        pairs.ShouldContain(p => p.ToString() == "EUR/BGN");
         pairs.ShouldContain(p => p.ToString() == "EUR/BRL");
         pairs.ShouldContain(p => p.ToString() == "EUR/CAD");
         pairs.ShouldContain(p => p.ToString() == "EUR/CHF");
@@ -220,6 +219,7 @@ public class EuropeanCentralBankTests
         pairs.ShouldContain(p => p.ToString() == "EUR/IDR");
         pairs.ShouldContain(p => p.ToString() == "EUR/ILS");
         pairs.ShouldContain(p => p.ToString() == "EUR/INR");
+        pairs.ShouldContain(p => p.ToString() == "EUR/ISK");
         pairs.ShouldContain(p => p.ToString() == "EUR/JPY");
         pairs.ShouldContain(p => p.ToString() == "EUR/KRW");
         pairs.ShouldContain(p => p.ToString() == "EUR/MXN");


### PR DESCRIPTION
## Summary
- Updated ECB current-feed expectations to match the live feed (`ISK` instead of stale `BGN`).
- Made ECB feed selection and cache keying use ECB local date semantics via `TimeZoneInfo` instead of raw UTC dates.
- Added a small per-provider XML cache to avoid repeated live downloads during ECB integration tests.
- Kept the provider retry-free; only the typed client registration carries the request header configuration.

## Testing
- Ran `EuropeanCentralBankTests` integration coverage locally.
- Verified all 15 ECB tests pass after the timezone and expectation updates.