### PR TITLE
Fix Central Bank of Armenia RSS endpoint

### DIFF
--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/CentralBankOfArmenia.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/CentralBankOfArmenia.cs
@@ -9,7 +9,7 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
     private static readonly CurrencyInfo AMD = new(new RegionInfo("hy-AM"));
 
     private static readonly Uri RSS =
-        new("https://www.cba.am/_layouts/rssreader.aspx?rss=280F57B8-763C-4EE4-90E0-8136C13E47DA");
+        new("https://old.cba.am/_layouts/rssreader.aspx?rss=280F57B8-763C-4EE4-90E0-8136C13E47DA");
 
     private readonly ICurrencyFactory currencyFactory;
     private readonly HttpClient httpClient;


### PR DESCRIPTION
## Summary
- Update the CentralBankOfArmenia RSS URL to the current `old.cba.am` HTTPS endpoint
- Avoid the `301 Moved Permanently` redirect that was breaking integration tests and masking validation failures

## Testing
- Ran the `CentralBankOfArmeniaTests` integration test class locally
- Verified the affected tests now pass against the live feed