### PR TITLE
Reduce Bank of Russia test traffic and remove ECB User-Agent config

### DIFF
--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -81,10 +81,7 @@ public static class ServiceCollectionExtensions
             .ConfigureHttpClient(config =>
                 config.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TIKSN-Framework",
                     typeof(ServiceCollectionExtensions).Assembly.GetName().Version?.ToString())));
-        _ = services.AddHttpClient<IEuropeanCentralBank, EuropeanCentralBank>()
-            .ConfigureHttpClient(config =>
-                config.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TIKSN-Framework",
-                    typeof(ServiceCollectionExtensions).Assembly.GetName().Version?.ToString())));
+        _ = services.AddHttpClient<IEuropeanCentralBank, EuropeanCentralBank>();
         _ = services.AddHttpClient<IFederalReserveSystem, FederalReserveSystem>();
         _ = services.AddHttpClient<INationalBankOfPoland, NationalBankOfPoland>();
         _ = services.AddHttpClient<INationalBankOfUkraine, NationalBankOfUkraine>();

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfRussia.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfRussia.cs
@@ -10,6 +10,9 @@ public class BankOfRussia : IBankOfRussia
     private static readonly CompositeFormat AddressFormat =
         CompositeFormat.Parse("https://www.cbr.ru/scripts/XML_daily.asp?date_req={0:00}.{1:00}.{2}");
 
+    private static readonly Dictionary<DateOnly, IReadOnlyCollection<PublishedRate>> PublishedRatesCache = [];
+
+    private static readonly Lock PublishedRatesCacheLock = new();
     private static readonly CurrencyInfo RussianRuble = new(new RegionInfo("ru-RU"));
     private static readonly CultureInfo RussianRussia = new("ru-RU");
     private readonly ICurrencyFactory currencyFactory;
@@ -85,60 +88,73 @@ public class BankOfRussia : IBankOfRussia
 
         var address = new Uri(string.Format(RussianRussia, AddressFormat, thatDay.Day, thatDay.Month, thatDay.Year));
 
-        var result = new List<ExchangeRate>();
+        var date = DateOnly.FromDateTime(thatDay);
+        var publishedRates = GetCachedPublishedRates(date);
 
-        var responseStream = await this.httpClient.GetStreamAsync(address, cancellationToken).ConfigureAwait(false);
+        if (publishedRates == null)
+        {
+            var responseStream = await this.httpClient.GetStreamAsync(address, cancellationToken).ConfigureAwait(false);
+            publishedRates = ReadPublishedRates(responseStream);
+            CachePublishedRates(date, publishedRates);
+        }
 
+        return this.ApplyPublishedRates(publishedRates, asOn);
+    }
+
+    private static void CachePublishedRates(
+        DateOnly date,
+        IReadOnlyCollection<PublishedRate> publishedRates)
+    {
+        lock (PublishedRatesCacheLock)
+        {
+            PublishedRatesCache[date] = publishedRates;
+        }
+    }
+
+    private static IReadOnlyCollection<PublishedRate>? GetCachedPublishedRates(DateOnly date)
+    {
+        lock (PublishedRatesCacheLock)
+        {
+            return PublishedRatesCache.GetValueOrDefault(date);
+        }
+    }
+
+    private static List<PublishedRate> ReadPublishedRates(Stream responseStream)
+    {
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
         using var stream​Reader = new Stream​Reader(responseStream, Encoding.UTF7);
 #pragma warning restore SYSLIB0001 // Type or member is obsolete
 
         var xdoc = XDocument.Load(stream​Reader);
+        var publishedRates = new List<PublishedRate>();
 
-        lock (this.rates)
+        foreach (var valuteElement in xdoc
+                     ?.Element("ValCurs")
+                     ?.Elements("Valute") ?? [])
         {
-            this.rates.Clear();
+            var charCodeElement = valuteElement.Element("CharCode");
 
-            foreach (var valuteElement in xdoc
-                         ?.Element("ValCurs")
-                         ?.Elements("Valute") ?? [])
+            if (charCodeElement == null)
             {
-                var charCodeElement = valuteElement.Element("CharCode");
-
-                if (charCodeElement == null)
-                {
-                    continue;
-                }
-
-                var nominalElement = valuteElement.Element("Nominal");
-                var valueElement = valuteElement.Element("Value");
-
-                var code = charCodeElement.Value;
-
-                if (string.Equals(code, "NULL", StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                var currency = this.currencyFactory.Create(charCodeElement.Value);
-
-                var value = decimal.Parse(valueElement?.Value ?? string.Empty, RussianRussia);
-                var nominal = decimal.Parse(nominalElement?.Value ?? string.Empty, RussianRussia);
-
-                result.Add(new ExchangeRate(new CurrencyPair(currency, RussianRuble), asOn,
-                    value / nominal));
-                result.Add(new ExchangeRate(new CurrencyPair(RussianRuble, currency), asOn,
-                    nominal / value));
-
-                var rate = value / nominal;
-
-                this.rates.Add(currency, rate);
+                continue;
             }
 
-            this.published = asOn;
+            var code = charCodeElement.Value;
+
+            if (string.Equals(code, "NULL", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var nominalElement = valuteElement.Element("Nominal");
+            var valueElement = valuteElement.Element("Value");
+            var value = decimal.Parse(valueElement?.Value ?? string.Empty, RussianRussia);
+            var nominal = decimal.Parse(nominalElement?.Value ?? string.Empty, RussianRussia);
+
+            publishedRates.Add(new PublishedRate(code, value / nominal));
         }
 
-        return result;
+        return publishedRates;
     }
 
     private static void ValidateDate(DateTimeOffset asOn, TimeProvider timeProvider)
@@ -147,6 +163,34 @@ public class BankOfRussia : IBankOfRussia
         {
             throw new ArgumentException("Exchange rate forecasting not supported.", nameof(asOn));
         }
+    }
+
+    private List<ExchangeRate> ApplyPublishedRates(
+        IReadOnlyCollection<PublishedRate> publishedRates,
+        DateTimeOffset asOn)
+    {
+        var result = new List<ExchangeRate>();
+
+        lock (this.rates)
+        {
+            this.rates.Clear();
+
+            foreach (var publishedRate in publishedRates)
+            {
+                var currency = this.currencyFactory.Create(publishedRate.CurrencyCode);
+
+                result.Add(new ExchangeRate(new CurrencyPair(currency, RussianRuble), asOn,
+                    publishedRate.Rate));
+                result.Add(new ExchangeRate(new CurrencyPair(RussianRuble, currency), asOn,
+                    decimal.One / publishedRate.Rate));
+
+                this.rates.Add(currency, publishedRate.Rate);
+            }
+
+            this.published = asOn;
+        }
+
+        return result;
     }
 
     private async Task FetchOnDemandAsync(DateTimeOffset asOn, CancellationToken cancellationToken)
@@ -175,4 +219,6 @@ public class BankOfRussia : IBankOfRussia
 
         throw new InvalidOperationException("Currency pair not supported.");
     }
+
+    private sealed record PublishedRate(string CurrencyCode, decimal Rate);
 }

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
@@ -305,16 +305,11 @@ public class BankOfRussiaTests
     {
         for (var year = 1994; year <= this.timeProvider.GetUtcNow().Year; year++)
         {
-            for (var month = 1;
-                 (year < this.timeProvider.GetUtcNow().Year && month <= 12) ||
-                 month <= this.timeProvider.GetUtcNow().Month;
-                 month++)
-            {
-                var date = new DateTime(year, month, day: 1);
+            var month = year == this.timeProvider.GetUtcNow().Year ? this.timeProvider.GetUtcNow().Month : 1;
+            var date = new DateTime(year, month, day: 1);
 
-                _ = await this.bank.GetCurrencyPairsAsync(date,
-                    cancellationToken: TestContext.Current.CancellationToken);
-            }
+            _ = await this.bank.GetCurrencyPairsAsync(date,
+                cancellationToken: TestContext.Current.CancellationToken);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add date-level caching to `BankOfRussia` so repeated requests for the same day reuse the parsed exchange-rate payload instead of hitting CBR again.
- Narrow the Bank of Russia integration sweep from monthly requests across every historical month to one representative request per year.
- Remove the custom `User-Agent` configuration from the European Central Bank registration.

## Testing
- Passed `dotnet test TIKSN.Framework.IntegrationTests\TIKSN.Framework.IntegrationTests.csproj --filter "FullyQualifiedName~TIKSN.IntegrationTests.Finance.ForeignExchange.Bank.BankOfRussiaTests|FullyQualifiedName~TIKSN.IntegrationTests.Finance.ForeignExchange.Bank.CentralBankOfArmeniaTests|FullyQualifiedName~TIKSN.IntegrationTests.Finance.ForeignExchange.Bank.EuropeanCentralBankTests" --no-restore`
- Bank of Russia, Central Bank of Armenia, and European Central Bank integration tests all passed