### PR TITLE
Add Monetary Authority of Singapore to exchange-rate service composition

### DIFF
--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -86,6 +86,7 @@ public static class ServiceCollectionExtensions
                     typeof(ServiceCollectionExtensions).Assembly.GetName().Version?.ToString())));
         _ = services.AddHttpClient<IEuropeanCentralBank, EuropeanCentralBank>();
         _ = services.AddHttpClient<IFederalReserveSystem, FederalReserveSystem>();
+        _ = services.AddHttpClient<IMonetaryAuthorityOfSingapore, MonetaryAuthorityOfSingapore>();
         _ = services.AddHttpClient<INationalBankOfPoland, NationalBankOfPoland>();
         _ = services.AddHttpClient<INationalBankOfUkraine, NationalBankOfUkraine>();
         _ = services.AddHttpClient<IReserveBankOfAustralia, ReserveBankOfAustralia>();

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/IMonetaryAuthorityOfSingapore.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/IMonetaryAuthorityOfSingapore.cs
@@ -1,0 +1,3 @@
+namespace TIKSN.Finance.ForeignExchange.Bank;
+
+public interface IMonetaryAuthorityOfSingapore : ICurrencyConverter, IExchangeRatesProvider;

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingapore.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingapore.cs
@@ -1,0 +1,258 @@
+using System.Globalization;
+using System.Text.Json;
+using NodaTime;
+using NodaTime.Extensions;
+using TIKSN.Globalization;
+
+namespace TIKSN.Finance.ForeignExchange.Bank;
+
+public class MonetaryAuthorityOfSingapore : IMonetaryAuthorityOfSingapore
+{
+    private const string DataSeriesPropertyName = "DataSeries";
+    private const string IdPropertyName = "_id";
+
+    private static readonly Uri DataStoreUrl =
+        new("https://data.gov.sg/api/action/datastore_search?resource_id=d_cdd73fd4341b345fa4307e44d6f82175&limit=100");
+
+    /// <summary>
+    /// Units is the foreign-currency quantity represented by each published SGD rate.
+    /// </summary>
+    private static readonly Dictionary<string, RateSeries> RateSeriesMap =
+        new Dictionary<string, RateSeries>(StringComparer.InvariantCulture)
+        {
+            ["Australian Dollar"] = new("AUD", Units: 1m),
+            ["Euro"] = new("EUR", Units: 1m),
+            ["Hong Kong Dollar"] = new("HKD", Units: 1m),
+            ["Indian Rupee"] = new("INR", Units: 100m),
+            ["Indonesian Rupiah"] = new("IDR", Units: 100m),
+            ["Japanese Yen"] = new("JPY", Units: 100m),
+            ["Korean Won"] = new("KRW", Units: 100m),
+            ["Malaysian Ringgit"] = new("MYR", Units: 1m),
+            ["New Taiwan Dollar"] = new("TWD", Units: 100m),
+            ["Philippine Peso"] = new("PHP", Units: 100m),
+            ["Renminbi"] = new("CNY", Units: 1m),
+            ["Sterling Pound"] = new("GBP", Units: 1m),
+            ["Swiss Franc"] = new("CHF", Units: 1m),
+            ["Thai Baht"] = new("THB", Units: 100m),
+            ["US Dollar"] = new("USD", Units: 1m),
+        };
+
+    private static readonly CurrencyInfo SingaporeDollar = new(new RegionInfo("en-SG"));
+    private static readonly DateTimeZone SingaporeTimeZone = DateTimeZoneProviders.Tzdb["Asia/Singapore"];
+
+    private readonly ICurrencyFactory currencyFactory;
+    private readonly HttpClient httpClient;
+    private readonly TimeProvider timeProvider;
+    private IReadOnlyCollection<ExchangeRate>? cachedRates;
+    private DateTimeOffset lastFetchDate;
+
+    public MonetaryAuthorityOfSingapore(
+        HttpClient httpClient,
+        ICurrencyFactory currencyFactory,
+        TimeProvider timeProvider)
+    {
+        this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        this.lastFetchDate = DateTimeOffset.MinValue;
+    }
+
+    public async Task<Money> ConvertCurrencyAsync(
+        Money baseMoney,
+        CurrencyInfo counterCurrency,
+        DateTimeOffset asOn,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(baseMoney);
+        ArgumentNullException.ThrowIfNull(counterCurrency);
+
+        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
+
+        return new Money(counterCurrency, baseMoney.Amount * rate);
+    }
+
+    public async Task<IReadOnlyCollection<CurrencyPair>> GetCurrencyPairsAsync(
+        DateTimeOffset asOn,
+        CancellationToken cancellationToken)
+    {
+        var rates = await this.GetRatesAsync(asOn, cancellationToken).ConfigureAwait(false);
+
+        return [.. rates.Select(x => x.Pair).Distinct()];
+    }
+
+    public async Task<decimal> GetExchangeRateAsync(
+        CurrencyPair pair,
+        DateTimeOffset asOn,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+
+        var rates = await this.GetRatesAsync(asOn, cancellationToken).ConfigureAwait(false);
+        var exchangeRate = rates.SingleOrDefault(x => x.Pair == pair);
+
+        if (exchangeRate is not null)
+        {
+            return exchangeRate.Rate;
+        }
+
+        throw new ArgumentException($"Currency pair '{pair}' not supported.", nameof(pair));
+    }
+
+    public async Task<IReadOnlyCollection<ExchangeRate>> GetExchangeRatesAsync(
+        DateTimeOffset asOn,
+        CancellationToken cancellationToken)
+        => await this.GetRatesAsync(asOn, cancellationToken).ConfigureAwait(false);
+
+    private static DateTimeOffset CreateSingaporeDateTimeOffset(DateOnly date)
+    {
+        var localDate = new LocalDate(date.Year, date.Month, date.Day);
+
+        return localDate.AtStartOfDayInZone(SingaporeTimeZone).ToDateTimeOffset();
+    }
+
+    private static DateTimeOffset CreateSingaporeMonthEndDateTimeOffset(int year, int month)
+    {
+        var day = DateTime.DaysInMonth(year, month);
+
+        return CreateSingaporeDateTimeOffset(new DateOnly(year, month, day));
+    }
+
+    private static DateOnly GetSingaporeDate(DateTimeOffset dateTime) =>
+        DateOnly.FromDateTime(dateTime.ToInstant().InZone(SingaporeTimeZone).ToDateTimeUnspecified());
+
+    private static bool TryGetRate(JsonElement value, out decimal rate)
+    {
+        if (value.ValueKind == JsonValueKind.Number)
+        {
+            return value.TryGetDecimal(out rate);
+        }
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            return decimal.TryParse(
+                value.GetString(),
+                NumberStyles.Number,
+                CultureInfo.InvariantCulture,
+                out rate);
+        }
+
+        rate = decimal.Zero;
+        return false;
+    }
+
+    private static bool TryParsePeriod(string fieldName, out DateTimeOffset asOn)
+    {
+        if (DateTime.TryParseExact(
+                fieldName,
+                "yyyyMMM",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var period))
+        {
+            asOn = CreateSingaporeMonthEndDateTimeOffset(period.Year, period.Month);
+            return true;
+        }
+
+        asOn = DateTimeOffset.MinValue;
+        return false;
+    }
+
+    private void AddExchangeRates(
+        List<ExchangeRate> rates,
+        RateSeries series,
+        JsonProperty property)
+    {
+        if (!TryParsePeriod(property.Name, out var asOn) ||
+            !TryGetRate(property.Value, out var rawRate) ||
+            rawRate <= decimal.Zero)
+        {
+            return;
+        }
+
+        var currency = this.currencyFactory.Create(series.CurrencyCode);
+        var rate = rawRate / series.Units;
+        var exchangeRate = new ExchangeRate(new CurrencyPair(currency, SingaporeDollar), asOn, rate);
+
+        rates.Add(exchangeRate);
+        rates.Add(exchangeRate.Reverse());
+    }
+
+    private async Task<IReadOnlyCollection<ExchangeRate>> FetchRatesAsync(CancellationToken cancellationToken)
+    {
+        var responseStream = await this.httpClient.GetStreamAsync(DataStoreUrl, cancellationToken).ConfigureAwait(false);
+
+        await using (responseStream.ConfigureAwait(false))
+        {
+            var root = await JsonSerializer
+                .DeserializeAsync<JsonElement>(responseStream, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            var rates = new List<ExchangeRate>();
+
+            foreach (var record in root.GetProperty("result").GetProperty("records").EnumerateArray())
+            {
+                var seriesName = record.GetProperty(DataSeriesPropertyName).GetString();
+
+                if (seriesName is null || !RateSeriesMap.TryGetValue(seriesName, out var series))
+                {
+                    continue;
+                }
+
+                foreach (var property in record.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, DataSeriesPropertyName, StringComparison.Ordinal) ||
+                        string.Equals(property.Name, IdPropertyName, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    this.AddExchangeRates(rates, series, property);
+                }
+            }
+
+            this.lastFetchDate = this.timeProvider.GetUtcNow();
+            this.cachedRates = rates;
+
+            return rates;
+        }
+    }
+
+    private async Task<IReadOnlyCollection<ExchangeRate>> GetAllRatesAsync(CancellationToken cancellationToken)
+    {
+        if (this.cachedRates is null || this.timeProvider.GetUtcNow() - this.lastFetchDate > TimeSpan.FromDays(1d))
+        {
+            return await this.FetchRatesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return this.cachedRates;
+    }
+
+    private async Task<IReadOnlyCollection<ExchangeRate>> GetRatesAsync(
+        DateTimeOffset asOn,
+        CancellationToken cancellationToken)
+    {
+        if (asOn > this.timeProvider.GetUtcNow())
+        {
+            throw new ArgumentException("Exchange rate forecasting are not supported.", nameof(asOn));
+        }
+
+        var allRates = await this.GetAllRatesAsync(cancellationToken).ConfigureAwait(false);
+        var singaporeDate = GetSingaporeDate(asOn);
+        var latestDate = allRates
+            .Where(x => GetSingaporeDate(x.AsOn) <= singaporeDate)
+            .Select(x => x.AsOn)
+            .Distinct()
+            .OrderByDescending(x => x)
+            .FirstOrDefault();
+
+        if (latestDate == DateTimeOffset.MinValue)
+        {
+            throw new ArgumentException("Exchange rate history not supported.", nameof(asOn));
+        }
+
+        return [.. allRates.Where(x => x.AsOn == latestDate).Distinct()];
+    }
+
+    private readonly record struct RateSeries(string CurrencyCode, decimal Units);
+}

--- a/TIKSN.Framework.Core/Localization/LocalizationKeys.cs
+++ b/TIKSN.Framework.Core/Localization/LocalizationKeys.cs
@@ -1044,6 +1044,12 @@ public static class LocalizationKeys
     public static string Key816611612 => "816611612";
 
     /// <summary>
+    /// Key: 827519006
+    /// Original Value: Monetary Authority of Singapore
+    /// </summary>
+    public static string Key827519006 => "827519006";
+
+    /// <summary>
     /// Key: 829543091
     /// Original Value: Developing for Developers
     /// </summary>

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingaporeTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingaporeTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Finance;
+using TIKSN.Finance.ForeignExchange.Bank;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.IntegrationTests.Finance.ForeignExchange.Bank;
+
+public class MonetaryAuthorityOfSingaporeTests
+{
+    private readonly IMonetaryAuthorityOfSingapore bank;
+    private readonly ICurrencyFactory currencyFactory;
+    private readonly TimeProvider timeProvider;
+
+    public MonetaryAuthorityOfSingaporeTests()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        this.bank = serviceProvider.GetRequiredService<IMonetaryAuthorityOfSingapore>();
+        this.currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        this.timeProvider = serviceProvider.GetRequiredService<TimeProvider>();
+    }
+
+    [Fact]
+    public async Task Given10USD_WhenUSDRateRequested_ThenResultShouldBeGreaterThan10SGD()
+    {
+        var theSGD = this.currencyFactory.Create("SGD");
+        var theUSD = this.currencyFactory.Create("USD");
+        var the10USD = new Money(theUSD, amount: 10m);
+
+        var result = await this.bank.ConvertCurrencyAsync(the10USD, theSGD, this.timeProvider.GetUtcNow(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        _ = result.ShouldNotBeNull();
+        result.Currency.ISOCurrencySymbol.ShouldBe("SGD");
+        result.Amount.ShouldBeGreaterThan(10m);
+    }
+
+    [Fact]
+    public async Task Given100SGD_WhenUSDRateRequested_ThenResultShouldBeLessThan100USD()
+    {
+        var theSGD = this.currencyFactory.Create("SGD");
+        var theUSD = this.currencyFactory.Create("USD");
+        var the100SGD = new Money(theSGD, amount: 100m);
+
+        var result = await this.bank.ConvertCurrencyAsync(the100SGD, theUSD, this.timeProvider.GetUtcNow(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        _ = result.ShouldNotBeNull();
+        result.Currency.ISOCurrencySymbol.ShouldBe("USD");
+        result.Amount.ShouldBeLessThan(100m);
+    }
+
+    [Fact]
+    public async Task Given_WhenPairsRequested_ThenResultShouldContainExpectedCurrencies()
+    {
+        var result = await this.bank.GetCurrencyPairsAsync(this.timeProvider.GetUtcNow(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        _ = result.ShouldNotBeNull();
+        result.ShouldNotBeEmpty();
+        result.ShouldBeUnique();
+        result.ShouldContain(x => x.ToString() == "USD/SGD");
+        result.ShouldContain(x => x.ToString() == "SGD/USD");
+        result.ShouldContain(x => x.ToString() == "JPY/SGD");
+        result.ShouldContain(x => x.ToString() == "SGD/JPY");
+    }
+
+    [Fact]
+    public async Task GivenHistoricalDate_WhenRateRequested_ThenResultShouldBePositive()
+    {
+        var theSGD = this.currencyFactory.Create("SGD");
+        var theUSD = this.currencyFactory.Create("USD");
+        var pair = new CurrencyPair(theUSD, theSGD);
+        var asOn = new DateTimeOffset(year: 2024, month: 12, day: 31, hour: 0, minute: 0, second: 0,
+            offset: TimeSpan.FromHours(8));
+
+        var result = await this.bank.GetExchangeRateAsync(pair, asOn,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeGreaterThan(decimal.Zero);
+    }
+
+    [Fact]
+    public async Task GivenFutureDate_WhenRateRequested_ThenItShouldThrowArgumentException()
+        => await new Func<Task>(async () =>
+                await this.bank.GetCurrencyPairsAsync(this.timeProvider.GetUtcNow().AddMinutes(1d),
+                    cancellationToken: TestContext.Current.CancellationToken))
+            .ShouldThrowAsync<ArgumentException>();
+}

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/ExchangeRateService/TestExchangeRateService.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/ExchangeRateService/TestExchangeRateService.cs
@@ -21,6 +21,7 @@ public sealed class TestExchangeRateService : ExchangeRateServiceBase
         ICentralBankOfArmenia centralBankOfArmenia,
         IEuropeanCentralBank europeanCentralBank,
         IFederalReserveSystem financeReserveSystem,
+        IMonetaryAuthorityOfSingapore monetaryAuthorityOfSingapore,
         INationalBankOfPoland nationalBankOfPoland,
         INationalBankOfUkraine nationalBankOfUkraine,
         IReserveBankOfAustralia reserveBankOfAustralia,
@@ -78,6 +79,14 @@ public sealed class TestExchangeRateService : ExchangeRateServiceBase
             LocalizationKeys.Key724813953,
             "US",
             TimeSpan.FromHours(24));
+
+        this.AddBatchProvider(
+            Guid.Parse("5bb733e2-c8ab-40f5-a51d-e7f3fb92746a"),
+            monetaryAuthorityOfSingapore,
+            LocalizationKeys.Key827519006,
+            LocalizationKeys.Key827519006,
+            "SG",
+            TimeSpan.FromDays(30));
 
         this.AddBatchProvider(
             Guid.Parse("cbe21065-1ead-463c-be4e-d95d30051101"),

--- a/TIKSN.LanguageLocalization/Strings.resx
+++ b/TIKSN.LanguageLocalization/Strings.resx
@@ -639,6 +639,9 @@
   <data name="758955736" xml:space="preserve">
     <value>Bank of England</value>
   </data>
+  <data name="827519006" xml:space="preserve">
+    <value>Monetary Authority of Singapore</value>
+  </data>
   <data name="937230874" xml:space="preserve">
     <value>The Central Bank of the Russian Federation</value>
   </data>


### PR DESCRIPTION
## Summary
- Registered `IMonetaryAuthorityOfSingapore` in `TestExchangeRateService` so the MAS provider participates in the integration exchange-rate composition.
- Added the MAS localization key and wired the provider with `SG` metadata and a monthly invalidation interval.
- Kept the new provider tests in place to cover supported pairs, conversion direction, historical lookup, and future-date rejection.

## Testing
- `dotnet test TIKSN.Framework.IntegrationTests\\TIKSN.Framework.IntegrationTests.csproj --no-restore --filter FullyQualifiedName~MonetaryAuthorityOfSingaporeTests /p:UseSharedCompilation=false`