### PR TITLE
Enable warning-free builds for core and localization

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -318,7 +318,7 @@ Task BuildLanguageLocalization EstimateVersion, {
     $project = Resolve-Path -Path 'TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj'
     $nextVersion = $state.NextVersion
 
-    Exec { dotnet build $project /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder }
+    Exec { dotnet build $project /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
 }
 
 # Synopsis: Build Region Localization
@@ -328,7 +328,7 @@ Task BuildRegionLocalization EstimateVersion, {
     $project = Resolve-Path -Path 'TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj'
     $nextVersion = $state.NextVersion
 
-    Exec { dotnet build $project /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder }
+    Exec { dotnet build $project /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
 }
 
 # Synopsis: Build Core
@@ -338,7 +338,7 @@ Task BuildCore EstimateVersion, DownloadCurrencyCodes, {
     $project = Resolve-Path -Path 'TIKSN.Framework.Core/TIKSN.Framework.Core.csproj'
     $nextVersion = $state.NextVersion
 
-    Exec { dotnet build $project /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder }
+    Exec { dotnet build $project /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
 }
 
 # Synopsis: Build MAUI

--- a/TIKSN.Framework.Core/Data/LiteDB/LiteDbRepository.cs
+++ b/TIKSN.Framework.Core/Data/LiteDB/LiteDbRepository.cs
@@ -61,7 +61,7 @@ public class LiteDbRepository<TDocument, TIdentity> : ILiteDbRepository<TDocumen
             ?? throw new EntityNotFoundException("Result retrieved from database is null.");
 
     public Task<TDocument?> GetOrDefaultAsync(TIdentity id, CancellationToken cancellationToken)
-        => Task.FromResult(this.Collection.FindById(this.ConvertToBsonValue(id)));
+        => Task.FromResult((TDocument?)this.Collection.FindById(this.ConvertToBsonValue(id)));
 
     public Task<IReadOnlyList<TDocument>> ListAsync(
         IEnumerable<TIdentity> ids,

--- a/TIKSN.Framework.Core/Data/Mongo/MongoClientProviderBase.cs
+++ b/TIKSN.Framework.Core/Data/Mongo/MongoClientProviderBase.cs
@@ -28,21 +28,24 @@ public abstract class MongoClientProviderBase : IMongoClientProvider, IDisposabl
 
     public IMongoClient GetMongoClient()
     {
-        if (this.mongoClient == null)
+        var client = this.mongoClient;
+        if (client is null)
         {
             lock (this.locker)
             {
-                if (this.mongoClient == null)
+                client = this.mongoClient;
+                if (client is null)
                 {
                     var connectionString = this.configuration.GetConnectionString(this.connectionStringKey);
                     var mongoClientSettings = MongoClientSettings.FromConnectionString(connectionString);
                     this.ConfigureClientSettings(mongoClientSettings);
-                    this.mongoClient = new MongoClient(mongoClientSettings);
+                    client = new MongoClient(mongoClientSettings);
+                    this.mongoClient = client;
                 }
             }
         }
 
-        return this.mongoClient;
+        return client;
     }
 
     protected virtual void ConfigureClientSettings(MongoClientSettings mongoClientSettings)
@@ -53,6 +56,11 @@ public abstract class MongoClientProviderBase : IMongoClientProvider, IDisposabl
     {
         if (!this.disposedValue)
         {
+            if (disposing)
+            {
+                this.mongoClient?.Dispose();
+            }
+
             this.disposedValue = true;
         }
     }

--- a/TIKSN.Framework.Core/Data/PageQuery.cs
+++ b/TIKSN.Framework.Core/Data/PageQuery.cs
@@ -1,6 +1,8 @@
 namespace TIKSN.Data;
 
+#pragma warning disable S4035 // Public model supports equality through IEquatable<T>.
 public class PageQuery : IEquatable<PageQuery>
+#pragma warning restore S4035 // Public model supports equality through IEquatable<T>.
 {
     public PageQuery(Page page, bool estimateTotalItems = false)
     {

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
@@ -11,6 +11,7 @@ public class EuropeanCentralBank : IEuropeanCentralBank
 
     private static readonly CurrencyInfo Euro = new(new RegionInfo("de-DE"));
 
+
     private static readonly SemaphoreSlim ExchangeRateDocumentSemaphore = new(initialCount: 1, maxCount: 1);
 
     private static readonly Dictionary<(Uri RequestURL, DateOnly RequestDate), XDocument> ExchangeRateDocuments = [];

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/ExchangeRate.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/ExchangeRate.cs
@@ -1,41 +1,12 @@
 namespace TIKSN.Finance.ForeignExchange;
 
-public class ExchangeRate : IEquatable<ExchangeRate>
+public record class ExchangeRate(CurrencyPair Pair, DateTimeOffset AsOn, decimal Rate)
 {
-    public ExchangeRate(CurrencyPair pair, DateTimeOffset asOn, decimal rate)
-    {
-        if (rate <= decimal.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rate), rate, "Rate must be a positive number.");
-        }
+    public CurrencyPair Pair { get; init; } = Pair ?? throw new ArgumentNullException(nameof(Pair));
 
-        this.Pair = pair ?? throw new ArgumentNullException(nameof(pair));
-        this.AsOn = asOn;
-        this.Rate = rate;
-    }
-
-    public DateTimeOffset AsOn { get; }
-
-    public CurrencyPair Pair { get; }
-
-    public decimal Rate { get; }
-
-    public bool Equals(ExchangeRate? other)
-    {
-        if (other == null)
-        {
-            return false;
-        }
-
-        return this.AsOn == other.AsOn
-            && this.Pair == other.Pair
-            && this.Rate == other.Rate;
-    }
-
-    public override bool Equals(object? obj) => this.Equals(obj as ExchangeRate);
-
-    public override int GetHashCode() =>
-        this.AsOn.GetHashCode() ^ this.Pair.GetHashCode() ^ this.Rate.GetHashCode();
+    public decimal Rate { get; init; } = Rate > decimal.Zero
+        ? Rate
+        : throw new ArgumentOutOfRangeException(nameof(Rate), Rate, "Rate must be a positive number.");
 
     public ExchangeRate Reverse() => new(this.Pair.Reverse(), this.AsOn, decimal.One / this.Rate);
 }

--- a/TIKSN.Framework.Core/Integration/Correlation/Base62CorrelationService.cs
+++ b/TIKSN.Framework.Core/Integration/Correlation/Base62CorrelationService.cs
@@ -10,7 +10,7 @@ public class Base62CorrelationService : ICorrelationService
 {
     private const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private const int Radix = 62;
-    private static readonly IReadOnlyDictionary<char, int> CodeMap = CreateCodeMap();
+    private static readonly Dictionary<char, int> CodeMap = CreateCodeMap();
 
     private readonly IOptions<Base62CorrelationServiceOptions> base62CorrelationServiceOptions;
     private readonly ICustomDeserializer<byte[], BigInteger> bigIntegerBinaryDeserializer;

--- a/TIKSN.Framework.Core/Integration/Correlation/CuidCorrelationService.cs
+++ b/TIKSN.Framework.Core/Integration/Correlation/CuidCorrelationService.cs
@@ -15,7 +15,7 @@ public class CuidCorrelationService : ICorrelationService
     private const int QuartetteUpperBoundary = 36 * 36 * 36 * 36;
     private const int Radix = 36;
     private const string UppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static readonly IReadOnlyDictionary<char, int> CodeMap = CreateCodeMap();
+    private static readonly Dictionary<char, int> CodeMap = CreateCodeMap();
     private readonly Lock locker;
     private readonly Random random;
     private readonly TimeProvider timeProvider;
@@ -298,30 +298,34 @@ public class CuidCorrelationService : ICorrelationService
         WriteBase36(value, chars);
     }
 
+    private string CreateHostname()
+    {
+#pragma warning disable CA1031 // Do not catch general exception types
+        try
+        {
+            return Environment.MachineName;
+        }
+        catch
+        {
+#pragma warning disable CA5394 // Do not use insecure randomness
+            return this.random.Next().ToString(CultureInfo.InvariantCulture);
+#pragma warning restore CA5394 // Do not use insecure randomness
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+    }
+
     private string GetHostname()
     {
-        if (this.hostname == null)
+        var currentHostname = this.hostname;
+        if (currentHostname is not null)
         {
-            lock (this.locker)
-            {
-                if (this.hostname == null)
-                {
-#pragma warning disable CA1031 // Do not catch general exception types
-                    try
-                    {
-                        this.hostname = Environment.MachineName;
-                    }
-                    catch
-                    {
-#pragma warning disable CA5394 // Do not use insecure randomness
-                        this.hostname = this.random.Next().ToString(CultureInfo.InvariantCulture);
-#pragma warning restore CA5394 // Do not use insecure randomness
-                    }
-#pragma warning restore CA1031 // Do not catch general exception types
-                }
-            }
+            return currentHostname;
         }
 
-        return this.hostname;
+        lock (this.locker)
+        {
+            this.hostname ??= this.CreateHostname();
+            return this.hostname;
+        }
     }
 }

--- a/TIKSN.Framework.Core/Integration/Messages/Commands/ICommand.cs
+++ b/TIKSN.Framework.Core/Integration/Messages/Commands/ICommand.cs
@@ -2,4 +2,6 @@ using MediatR;
 
 namespace TIKSN.Integration.Messages.Commands;
 
+#pragma warning disable CA1040 // Marker interface for framework command messages.
 public interface ICommand : IRequest<Unit>;
+#pragma warning restore CA1040 // Marker interface for framework command messages.

--- a/TIKSN.Framework.Core/Integration/Messages/Events/IEvent.cs
+++ b/TIKSN.Framework.Core/Integration/Messages/Events/IEvent.cs
@@ -2,4 +2,6 @@ using MediatR;
 
 namespace TIKSN.Integration.Messages.Events;
 
+#pragma warning disable CA1040 // Marker interface for framework event messages.
 public interface IEvent : INotification;
+#pragma warning restore CA1040 // Marker interface for framework event messages.

--- a/TIKSN.Framework.Core/Integration/Messages/Queries/IQuery.cs
+++ b/TIKSN.Framework.Core/Integration/Messages/Queries/IQuery.cs
@@ -2,4 +2,6 @@ using MediatR;
 
 namespace TIKSN.Integration.Messages.Queries;
 
+#pragma warning disable CA1040 // Marker interface for framework query messages.
 public interface IQuery<out TResult> : IRequest<TResult>;
+#pragma warning restore CA1040 // Marker interface for framework query messages.

--- a/TIKSN.Framework.Core/Licensing/EdDSACertificateSignatureService.cs
+++ b/TIKSN.Framework.Core/Licensing/EdDSACertificateSignatureService.cs
@@ -5,7 +5,9 @@ using Org.BouncyCastle.X509;
 
 namespace TIKSN.Licensing;
 
+#pragma warning disable S101 // EdDSA is the conventional cryptographic algorithm spelling.
 public class EdDSACertificateSignatureService : ICertificateSignatureService
+#pragma warning restore S101 // EdDSA is the conventional cryptographic algorithm spelling.
 {
     public byte[] Sign(
         byte[] data,

--- a/TIKSN.Framework.Core/Localization/StringLocalizerMonitor.cs
+++ b/TIKSN.Framework.Core/Localization/StringLocalizerMonitor.cs
@@ -7,7 +7,7 @@ namespace TIKSN.Localization;
 /// <summary>
 ///     IStringLocalizer decorator for monitoring not found resources.
 /// </summary>
-public class StringLocalizerMonitor : IStringLocalizer
+public partial class StringLocalizerMonitor : IStringLocalizer
 {
     private readonly ILogger<StringLocalizerMonitor> logger;
     private readonly IOptions<StringLocalizerMonitorOptions> options;
@@ -26,12 +26,16 @@ public class StringLocalizerMonitor : IStringLocalizer
     public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) =>
         this.stringLocalizer.GetAllStrings(includeParentCultures);
 
+    [LoggerMessage(
+        EventId = 76338392,
+        Message = "Resource with name '{ResourceName}' is not found.")]
+    private static partial void LogResourceNotFound(ILogger logger, LogLevel logLevel, string resourceName);
+
     private LocalizedString Log(LocalizedString localizedString)
     {
         if (localizedString.ResourceNotFound)
         {
-            this.logger.Log(this.options.Value.LogLevel, eventId: 414761847,
-                $"Resource with name '{localizedString.Name}' is not found.", exception: null, (s, _) => s);
+            LogResourceNotFound(this.logger, this.options.Value.LogLevel, localizedString.Name);
         }
 
         return localizedString;

--- a/TIKSN.Framework.Core/Numbering/A1Notation.cs
+++ b/TIKSN.Framework.Core/Numbering/A1Notation.cs
@@ -6,6 +6,7 @@ using static LanguageExt.Prelude;
 
 namespace TIKSN.Numbering;
 
+#pragma warning disable CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.
 public sealed class A1Notation<TNumber> : ISerialNumber<A1Notation<TNumber>>
     where TNumber : IUnsignedNumber<TNumber>
 {
@@ -97,3 +98,4 @@ public sealed class A1Notation<TNumber> : ISerialNumber<A1Notation<TNumber>>
         Validate(Option<SimpleSerialNumber<BB26, TNumber>> serialNumber) =>
         serialNumber.Bind(x => TNumber.IsZero(x.Number) ? None : Some(x));
 }
+#pragma warning restore CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.

--- a/TIKSN.Framework.Core/Numbering/NumberFirstSerialNumber.cs
+++ b/TIKSN.Framework.Core/Numbering/NumberFirstSerialNumber.cs
@@ -7,7 +7,8 @@ using static LanguageExt.Prelude;
 
 namespace TIKSN.Numbering;
 
-#pragma warning disable CA1000 // Do not declare static members on generic types
+#pragma warning disable CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.
+#pragma warning disable S1481 // Parser query range variables are required by query syntax.
 public sealed class NumberFirstSerialNumber<TNumber, TSerial> :
     ISerialNumber<NumberFirstSerialNumber<TNumber, TSerial>>
     where TNumber : IUnsignedNumber<TNumber>
@@ -200,4 +201,5 @@ public sealed class NumberFirstSerialNumber<TNumber, TSerial> :
         return charsWritten == result.Length;
     }
 }
-#pragma warning restore CA1000 // Do not declare static members on generic types
+#pragma warning restore S1481 // Parser query range variables are required by query syntax.
+#pragma warning restore CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.

--- a/TIKSN.Framework.Core/Numbering/OneANotation.cs
+++ b/TIKSN.Framework.Core/Numbering/OneANotation.cs
@@ -6,6 +6,7 @@ using static LanguageExt.Prelude;
 
 namespace TIKSN.Numbering;
 
+#pragma warning disable CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.
 public sealed class OneANotation<TNumber> : ISerialNumber<OneANotation<TNumber>>
     where TNumber : IUnsignedNumber<TNumber>
 {
@@ -100,3 +101,4 @@ public sealed class OneANotation<TNumber> : ISerialNumber<OneANotation<TNumber>>
         Validate(Option<NumberFirstSerialNumber<TNumber, BB26>> serialNumber) =>
         serialNumber.Bind(x => TNumber.IsZero(x.Number) ? None : Some(x));
 }
+#pragma warning restore CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.

--- a/TIKSN.Framework.Core/Numbering/SimpleSerialNumber.cs
+++ b/TIKSN.Framework.Core/Numbering/SimpleSerialNumber.cs
@@ -7,7 +7,8 @@ using static LanguageExt.Prelude;
 
 namespace TIKSN.Numbering;
 
-#pragma warning disable CA1000 // Do not declare static members on generic types
+#pragma warning disable CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.
+#pragma warning disable S1481 // Parser query range variables are required by query syntax.
 public sealed class SimpleSerialNumber<TSerial, TNumber> : ISerialNumber<SimpleSerialNumber<TSerial, TNumber>>
     where TSerial : ISerial<TSerial>
     where TNumber : IUnsignedNumber<TNumber>
@@ -193,4 +194,5 @@ public sealed class SimpleSerialNumber<TSerial, TNumber> : ISerialNumber<SimpleS
         return charsWritten == result.Length;
     }
 }
-#pragma warning restore CA1000 // Do not declare static members on generic types
+#pragma warning restore S1481 // Parser query range variables are required by query syntax.
+#pragma warning restore CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.

--- a/TIKSN.Framework.Core/Numbering/VariantSerialNumber.cs
+++ b/TIKSN.Framework.Core/Numbering/VariantSerialNumber.cs
@@ -7,7 +7,8 @@ using static LanguageExt.Prelude;
 
 namespace TIKSN.Numbering;
 
-#pragma warning disable CA1000 // Do not declare static members on generic types
+#pragma warning disable CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.
+#pragma warning disable S1481 // Parser query range variables are required by query syntax.
 public sealed class
     VariantSerialNumber<TSerial, TNumber, TVariant> : ISerialNumber<VariantSerialNumber<TSerial, TNumber, TVariant>>
     where TSerial : ISerial<TSerial>
@@ -211,4 +212,5 @@ public sealed class
         return charsWritten == result.Length;
     }
 }
-#pragma warning restore CA1000 // Do not declare static members on generic types
+#pragma warning restore S1481 // Parser query range variables are required by query syntax.
+#pragma warning restore CA1000 // Parse/TryParse members intentionally follow .NET parsing conventions.

--- a/TIKSN.Framework.Core/Parsing/ParserResultExtensions.cs
+++ b/TIKSN.Framework.Core/Parsing/ParserResultExtensions.cs
@@ -5,10 +5,15 @@ namespace TIKSN.Parsing;
 
 public static class ParserResultExtensions
 {
-    public static T GetOrThrow<T>(this ParserResult<T> parserResult) => parserResult.Match(
-        e => throw CreateValidationException(e),
-        c => throw CreateValidationException(c),
-        o => o.Reply.Result);
+    public static T GetOrThrow<T>(this ParserResult<T> parserResult)
+    {
+        ArgumentNullException.ThrowIfNull(parserResult);
+
+        return parserResult.Match(
+            e => throw CreateValidationException(e),
+            c => throw CreateValidationException(c),
+            o => o.Reply.Result);
+    }
 
     private static ValidationException CreateValidationException(ParserError error) => new(error.Msg);
 }

--- a/TIKSN.Framework.Core/Serialization/DotNetXmlDeserializer.cs
+++ b/TIKSN.Framework.Core/Serialization/DotNetXmlDeserializer.cs
@@ -9,11 +9,12 @@ public class DotNetXmlDeserializer : DeserializerBase<string>
     {
         if (string.IsNullOrEmpty(serial))
         {
-            return default;
+            throw new ArgumentException("Serialized XML cannot be null or empty.", nameof(serial));
         }
 
         using var xmlReader = XmlReader.Create(new StringReader(serial));
         var serializer = new XmlSerializer(typeof(T));
-        return (T)serializer.Deserialize(xmlReader);
+        return (T)(serializer.Deserialize(xmlReader) ??
+            throw new InvalidOperationException($"XML deserialization returned null for type '{typeof(T)}'."));
     }
 }

--- a/TIKSN.Framework.Core/Settings/FileSettingsService.cs
+++ b/TIKSN.Framework.Core/Settings/FileSettingsService.cs
@@ -198,6 +198,12 @@ public class FileSettingsService : ISettingsService
 
     private static T SetterProcessor<T>(BsonDocument document, string name, T value)
     {
+        if (value is null)
+        {
+            document[name] = BsonValue.Null;
+            return value;
+        }
+
         object valueObject = value;
 
         var type = typeof(T);
@@ -320,7 +326,7 @@ public class FileSettingsService : ISettingsService
 
     private string[] ListNames(IFileProvider fileProvider)
     {
-        using var db = this.GetDatabase(fileProvider, out var settingsCollection, out var bsonDocument);
+        using var db = this.GetDatabase(fileProvider, out _, out var bsonDocument);
         return [.. bsonDocument.Keys.Where(n => !string.Equals(n, "_id", StringComparison.OrdinalIgnoreCase))];
     }
 }

--- a/TIKSN.Framework.Core/Shell/ShellCommandEngine.cs
+++ b/TIKSN.Framework.Core/Shell/ShellCommandEngine.cs
@@ -235,7 +235,8 @@ public partial class ShellCommandEngine : IShellCommandEngine
     [LoggerMessage(
         EventId = 5833260,
         Level = LogLevel.Trace,
-        Message = "Parameter '{ParameterLocalizedName}' has value '{ParameterValue}'")]
+        Message = "Parameter '{ParameterLocalizedName}' has value '{ParameterValue}'",
+        SkipEnabledCheck = true)]
     private static partial void LogParameterNameAndValue(ILogger logger, string parameterLocalizedName,
         object? parameterValue);
 
@@ -352,8 +353,12 @@ public partial class ShellCommandEngine : IShellCommandEngine
                         property.Item2.SetValue(obj, parameter);
                     }
 
-                    LogParameterNameAndValue(this.logger, property.Item1.GetName(this.stringLocalizer),
-                        property.Item2.GetValue(obj));
+                    if (this.logger.IsEnabled(LogLevel.Trace))
+                    {
+                        var parameterLocalizedName = property.Item1.GetName(this.stringLocalizer);
+                        var parameterValue = property.Item2.GetValue(obj);
+                        LogParameterNameAndValue(this.logger, parameterLocalizedName, parameterValue);
+                    }
                 }
 
                 var command = obj as IShellCommand;

--- a/TIKSN.Framework.Core/Web/Rest/SerializationRestFactory.cs
+++ b/TIKSN.Framework.Core/Web/Rest/SerializationRestFactory.cs
@@ -4,7 +4,7 @@ namespace TIKSN.Web.Rest;
 
 public sealed class SerializationRestFactory : ISerializerRestFactory, IDeserializerRestFactory
 {
-    private readonly IDictionary<string, Tuple<ISerializer<string>, IDeserializer<string>>> map;
+    private readonly Dictionary<string, Tuple<ISerializer<string>, IDeserializer<string>>> map;
 
     public SerializationRestFactory(JsonSerializer jsonSerializer, JsonDeserializer jsonDeserializer,
         DotNetXmlSerializer dotNetXmlSerializer, DotNetXmlDeserializer dotNetXmlDeserializer) => this.map =

--- a/TIKSN.Framework.Core/Web/UriTemplate.cs
+++ b/TIKSN.Framework.Core/Web/UriTemplate.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace TIKSN.Web;
 
 public class UriTemplate
@@ -13,37 +15,36 @@ public class UriTemplate
 
     public Uri Compose()
     {
-        var resourceLocation = this.template;
+        var resourceLocation = new StringBuilder(this.template);
 
         foreach (var parameter in this.values)
         {
             var parameterName = $"{{{parameter.Key}}}";
             var escapedParameterValue = Uri.EscapeDataString(parameter.Value) ?? string.Empty;
 
-            if (resourceLocation.Contains(parameterName, StringComparison.Ordinal))
+            if (resourceLocation.ToString().Contains(parameterName, StringComparison.Ordinal))
             {
-                resourceLocation =
-                    resourceLocation.Replace(parameterName, escapedParameterValue, StringComparison.Ordinal);
+                _ = resourceLocation.Replace(parameterName, escapedParameterValue);
             }
             else
             {
                 var queryToAppend = $"{parameterName}={escapedParameterValue}";
-                if (resourceLocation.EndsWith('?'))
+                if (resourceLocation.Length > 0 && resourceLocation[^1] == '?')
                 {
-                    resourceLocation += queryToAppend;
+                    _ = resourceLocation.Append(queryToAppend);
                 }
-                else if (resourceLocation.Contains(value: '?', StringComparison.Ordinal))
+                else if (resourceLocation.ToString().Contains(value: '?', StringComparison.Ordinal))
                 {
-                    resourceLocation = $"{resourceLocation}&{queryToAppend}";
+                    _ = resourceLocation.Append('&').Append(queryToAppend);
                 }
                 else
                 {
-                    resourceLocation = $"{resourceLocation}?{queryToAppend}";
+                    _ = resourceLocation.Append('?').Append(queryToAppend);
                 }
             }
         }
 
-        return new Uri(resourceLocation, UriKind.Relative);
+        return new Uri(resourceLocation.ToString(), UriKind.Relative);
     }
 
     public void Fill(string name, string value) => this.values.Add(name, value);

--- a/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
+++ b/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup Label="MultilingualAppToolkit">
     <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
     <MultilingualFallbackLanguage>en</MultilingualFallbackLanguage>
+    <MultilingualAppToolkitVersionedTargets>$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets</MultilingualAppToolkitVersionedTargets>
+    <MultilingualAppToolkitUnversionedTargets>$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets</MultilingualAppToolkitUnversionedTargets>
+    <MultilingualAppToolkitTargets Condition="'$(MultilingualAppToolkitTargets)' == '' and Exists('$(MultilingualAppToolkitVersionedTargets)')">$(MultilingualAppToolkitVersionedTargets)</MultilingualAppToolkitTargets>
+    <MultilingualAppToolkitTargets Condition="'$(MultilingualAppToolkitTargets)' == '' and Exists('$(MultilingualAppToolkitUnversionedTargets)')">$(MultilingualAppToolkitUnversionedTargets)</MultilingualAppToolkitTargets>
     <TranslationReport Condition="'$(Configuration)' == 'Release'">true</TranslationReport>
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\TIKSN.LanguageLocalization.xml</DocumentationFile>
@@ -26,8 +30,8 @@
     <NoWarn>1701;1702;CS1591</NoWarn>
     <!-- <TreatWarningsAsErrors>True</TreatWarningsAsErrors> -->
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
+  <Import Project="$(MultilingualAppToolkitTargets)" Label="MultilingualAppToolkit" Condition="'$(MultilingualAppToolkitTargets)' != ''" />
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="'$(MultilingualAppToolkitTargets)' == '' and '$(BuildingInsideVisualStudio)' == 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
   <ItemGroup>

--- a/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
+++ b/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup Label="MultilingualAppToolkit">
     <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
     <MultilingualFallbackLanguage>en-US</MultilingualFallbackLanguage>
+    <MultilingualAppToolkitVersionedTargets>$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets</MultilingualAppToolkitVersionedTargets>
+    <MultilingualAppToolkitUnversionedTargets>$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets</MultilingualAppToolkitUnversionedTargets>
+    <MultilingualAppToolkitTargets Condition="'$(MultilingualAppToolkitTargets)' == '' and Exists('$(MultilingualAppToolkitVersionedTargets)')">$(MultilingualAppToolkitVersionedTargets)</MultilingualAppToolkitTargets>
+    <MultilingualAppToolkitTargets Condition="'$(MultilingualAppToolkitTargets)' == '' and Exists('$(MultilingualAppToolkitUnversionedTargets)')">$(MultilingualAppToolkitUnversionedTargets)</MultilingualAppToolkitTargets>
     <TranslationReport Condition="'$(Configuration)' == 'Release'">true</TranslationReport>
     <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\TIKSN.RegionLocalization.xml</DocumentationFile>
@@ -26,8 +30,8 @@
     <NoWarn>1701;1702;CS1591</NoWarn>
     <!-- <TreatWarningsAsErrors>True</TreatWarningsAsErrors> -->
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
+  <Import Project="$(MultilingualAppToolkitTargets)" Label="MultilingualAppToolkit" Condition="'$(MultilingualAppToolkitTargets)' != ''" />
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="'$(MultilingualAppToolkitTargets)' == '' and '$(BuildingInsideVisualStudio)' == 'true'" Label="MultilingualAppToolkit">
     <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
   </Target>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Turned on warnings-as-errors for Core, LanguageLocalization, and RegionLocalization in the build script
- Fixed the resulting Core warnings, including nullable handling, logging, XML deserialization, and a few analyzer findings
- Converted `ExchangeRate` to a `record class` and updated localization project imports so CLI builds stay clean when MAT is unavailable

## Testing
- `dotnet build TIKSN.Framework.Core\TIKSN.Framework.Core.csproj /v:m -warnaserror /p:Configuration=Release /p:TreatWarningsAsErrors=true`
- `dotnet build TIKSN.LanguageLocalization\TIKSN.LanguageLocalization.csproj /v:m -warnaserror /p:Configuration=Release /p:TreatWarningsAsErrors=true`
- `dotnet build TIKSN.RegionLocalization\TIKSN.RegionLocalization.csproj /v:m -warnaserror /p:Configuration=Release /p:TreatWarningsAsErrors=true`
- `./test.ps1`