### PR TITLE
Add CurrencyPairFactory and migrate currency pair creation to it

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request_target:
     types:
       - edited

--- a/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
+++ b/TIKSN.Framework.Core.Tests/DependencyInjection/RegistrationsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using TIKSN.DependencyInjection;
+using TIKSN.Finance;
 using TIKSN.Globalization;
 using Xunit;
 
@@ -40,6 +41,7 @@ public class RegistrationsTests : IDisposable
     [InlineData(typeof(ICultureFactory))]
     [InlineData(typeof(IRegionFactory))]
     [InlineData(typeof(ICurrencyFactory))]
+    [InlineData(typeof(ICurrencyPairFactory))]
     [InlineData(typeof(IDateTimeZoneLookup))]
     [InlineData(typeof(ITimeZoneInfoLookup))]
     public void GivenHost_WhenServiceResolved_ThenItShouldNotBeNull(Type serviceType)

--- a/TIKSN.Framework.Core.Tests/Finance/Cache/CachedCurrencyConverterTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/Cache/CachedCurrencyConverterTests.cs
@@ -13,7 +13,7 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_001()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
@@ -21,7 +21,7 @@ public class CachedCurrencyConverterTests
         var capacity = 20;
 
         var cachedConverter =
-            new CachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, capacity, capacity);
+            CreateCachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, capacity, capacity);
 
         cachedConverter.RatesCacheInterval.ShouldBe(interval);
         cachedConverter.CurrencyPairsCacheInterval.ShouldBe(interval);
@@ -36,13 +36,13 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_002()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
         var interval = TimeSpan.FromDays(10);
 
-        var cachedConverter = new CachedCurrencyConverter(converter, fakeTimeProvider, interval, interval);
+        var cachedConverter = CreateCachedCurrencyConverter(converter, fakeTimeProvider, interval, interval);
 
         cachedConverter.CurrencyPairsCacheInterval.ShouldBe(interval);
         cachedConverter.RatesCacheInterval.ShouldBe(interval);
@@ -58,13 +58,13 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_003()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
         var interval = TimeSpan.FromDays(10);
 
-        var cachedConverter = new CachedCurrencyConverter(converter, fakeTimeProvider, interval, interval);
+        var cachedConverter = CreateCachedCurrencyConverter(converter, fakeTimeProvider, interval, interval);
 
         cachedConverter.RatesCacheSize.ShouldBe(0);
         cachedConverter.CurrencyPairsCacheSize.ShouldBe(0);
@@ -80,7 +80,8 @@ public class CachedCurrencyConverterTests
         var capacity = 20;
 
         _ = new Func<object>(() =>
-                new CachedCurrencyConverter(originalConverter: null, fakeTimeProvider, interval, interval, capacity,
+                new CachedCurrencyConverter(null, Helper.CurrencyPairFactory, fakeTimeProvider, interval, interval,
+                    capacity,
                     capacity))
             .ShouldThrow<ArgumentNullException>();
     }
@@ -89,7 +90,7 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_NegativeCapacity001()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
@@ -98,7 +99,7 @@ public class CachedCurrencyConverterTests
         var positiveCapacity = 10;
 
         _ = new Func<object>(() =>
-            new CachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, negativeCapacity,
+            CreateCachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, negativeCapacity,
                 positiveCapacity)).ShouldThrow<ArgumentOutOfRangeException>();
     }
 
@@ -106,7 +107,7 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_NegativeCapacity002()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
@@ -115,7 +116,7 @@ public class CachedCurrencyConverterTests
         var positiveCapacity = 10;
 
         _ = new Func<object>(() =>
-            new CachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, positiveCapacity,
+            CreateCachedCurrencyConverter(converter, fakeTimeProvider, interval, interval, positiveCapacity,
                 negativeCapacity)).ShouldThrow<ArgumentOutOfRangeException>();
     }
 
@@ -123,7 +124,7 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_NegativeInterval001()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
@@ -131,7 +132,7 @@ public class CachedCurrencyConverterTests
         var positiveInterval = TimeSpan.FromDays(10);
 
         _ = new Func<object>(() =>
-                new CachedCurrencyConverter(converter, fakeTimeProvider, negativeInterval, positiveInterval))
+                CreateCachedCurrencyConverter(converter, fakeTimeProvider, negativeInterval, positiveInterval))
             .ShouldThrow<ArgumentOutOfRangeException>();
     }
 
@@ -139,7 +140,7 @@ public class CachedCurrencyConverterTests
     public void CachedCurrencyConverter_NegativeInterval002()
     {
         var converter =
-            new FixedRateCurrencyConverter(Helper.SampleCurrencyPair1, Helper.GetRandomForeignExchangeRate());
+            CreateFixedRateCurrencyConverter(Helper.SampleCurrencyPair1);
         var fakeTimeProvider = new FakeTimeProvider(new DateTimeOffset(year: 2020, month: 12, day: 31, hour: 0,
             minute: 0, second: 0, TimeSpan.Zero));
 
@@ -147,7 +148,26 @@ public class CachedCurrencyConverterTests
         var positiveInterval = TimeSpan.FromDays(10);
 
         _ = new Func<object>(() =>
-                new CachedCurrencyConverter(converter, fakeTimeProvider, positiveInterval, negativeInterval))
+                CreateCachedCurrencyConverter(converter, fakeTimeProvider, positiveInterval, negativeInterval))
             .ShouldThrow<ArgumentOutOfRangeException>();
     }
+
+    private static CachedCurrencyConverter CreateCachedCurrencyConverter(
+        ICurrencyConverter converter,
+        TimeProvider timeProvider,
+        TimeSpan ratesCacheInterval,
+        TimeSpan currencyPairsCacheInterval,
+        int? ratesCacheCapacity = null,
+        int? currencyPairsCacheCapacity = null)
+        => new(
+            converter,
+            Helper.CurrencyPairFactory,
+            timeProvider,
+            ratesCacheInterval,
+            currencyPairsCacheInterval,
+            ratesCacheCapacity,
+            currencyPairsCacheCapacity);
+
+    private static FixedRateCurrencyConverter CreateFixedRateCurrencyConverter(CurrencyPair pair)
+        => new(pair, Helper.GetRandomForeignExchangeRate(), Helper.CurrencyPairFactory);
 }

--- a/TIKSN.Framework.Core.Tests/Finance/Cache/MemoryCachedCurrencyConverterTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/Cache/MemoryCachedCurrencyConverterTests.cs
@@ -48,7 +48,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -73,7 +73,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -98,7 +98,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -127,7 +127,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -160,7 +160,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -197,7 +197,7 @@ public class MemoryCachedCurrencyConverterTests
         var originalConverter = Substitute.For<ICurrencyConverter>();
         var expectedPairs = new List<CurrencyPair>
         {
-            new(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
+            Helper.CurrencyPairFactory.Create("USD", "EUR"),
         };
 
         _ = originalConverter.GetCurrencyPairsAsync(moment1, cancellationToken: TestContext.Current.CancellationToken)
@@ -227,7 +227,7 @@ public class MemoryCachedCurrencyConverterTests
     public async Task GetExchangeRate001()
     {
         var exchangeRate = 10.23m;
-        var pair = new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("EUR"));
+        var pair = Helper.CurrencyPairFactory.Create("USD", "EUR");
 
         var moment1 = new DateTimeOffset(year: 2015, month: 12, day: 1, hour: 0, minute: 0, second: 0,
             TimeSpan.FromHours(2));
@@ -267,7 +267,7 @@ public class MemoryCachedCurrencyConverterTests
     public async Task GetExchangeRate002()
     {
         var exchangeRate = 10.23m;
-        var pair = new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("EUR"));
+        var pair = Helper.CurrencyPairFactory.Create("USD", "EUR");
 
         var moment1 = new DateTimeOffset(year: 2015, month: 12, day: 1, hour: 0, minute: 0, second: 0,
             TimeSpan.FromHours(2));

--- a/TIKSN.Framework.Core.Tests/Finance/CompositeCrossCurrencyConverterTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/CompositeCrossCurrencyConverterTests.cs
@@ -13,12 +13,9 @@ public class CompositeCrossCurrencyConverterTests
     {
         var converter = new CompositeCrossCurrencyConverter(new AverageCurrencyConversionCompositionStrategy());
 
-        converter.Add(new FixedRateCurrencyConverter(new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
-            rate: 1.12m));
-        converter.Add(new FixedRateCurrencyConverter(new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("GBP")),
-            rate: 1.13m));
-        converter.Add(new FixedRateCurrencyConverter(new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("CHF")),
-            rate: 1.14m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "EUR", rate: 1.12m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "GBP", rate: 1.13m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "CHF", rate: 1.14m));
 
         var pairs = await converter.GetCurrencyPairsAsync(DateTimeOffset.Now,
             cancellationToken: TestContext.Current.CancellationToken);
@@ -31,18 +28,23 @@ public class CompositeCrossCurrencyConverterTests
     {
         var converter = new CompositeCrossCurrencyConverter(new AverageCurrencyConversionCompositionStrategy());
 
-        converter.Add(new FixedRateCurrencyConverter(new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("EUR")),
-            rate: 1.12m));
-        converter.Add(new FixedRateCurrencyConverter(
-            new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("GBP")),
-            rate: 1.13m));
-        converter.Add(new FixedRateCurrencyConverter(new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("CHF")),
-            rate: 1.14m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "EUR", rate: 1.12m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "GBP", rate: 1.13m));
+        converter.Add(CreateFixedRateCurrencyConverter("USD", "CHF", rate: 1.14m));
 
         var rate = await converter.GetExchangeRateAsync(
-            new CurrencyPair(new CurrencyInfo("USD"), new CurrencyInfo("EUR")), DateTimeOffset.Now,
+            Helper.CurrencyPairFactory.Create("USD", "EUR"), DateTimeOffset.Now,
             cancellationToken: TestContext.Current.CancellationToken);
 
         rate.ShouldBe(1.12m);
     }
+
+    private static FixedRateCurrencyConverter CreateFixedRateCurrencyConverter(
+        string baseIsoCurrencySymbol,
+        string counterIsoCurrencySymbol,
+        decimal rate)
+        => new(
+            Helper.CurrencyPairFactory.Create(baseIsoCurrencySymbol, counterIsoCurrencySymbol),
+            rate,
+            Helper.CurrencyPairFactory);
 }

--- a/TIKSN.Framework.Core.Tests/Finance/CurrencyPairFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/CurrencyPairFactoryTests.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using TIKSN.DependencyInjection;
+using TIKSN.Finance;
+using TIKSN.Globalization;
+using Xunit;
+
+namespace TIKSN.Tests.Finance;
+
+public class CurrencyPairFactoryTests
+{
+    [Fact]
+    public void GivenCountries_WhenCurrencyPairCreated_ThenPrincipalRegionCurrenciesShouldBeUsed()
+    {
+        var serviceProvider = CreateServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var currencyPairFactory = serviceProvider.GetRequiredService<ICurrencyPairFactory>();
+
+        var pair = currencyPairFactory.Create(countryFactory.Create("US"), countryFactory.Create("GB"));
+
+        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("USD");
+        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("GBP");
+    }
+
+    [Fact]
+    public void GivenCurrencyInfos_WhenCurrencyPairCreated_ThenPairShouldMatch()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+        var usd = new CurrencyInfo("USD");
+        var eur = new CurrencyInfo("EUR");
+
+        var pair = currencyPairFactory.Create(usd, eur);
+
+        pair.BaseCurrency.ShouldBe(usd);
+        pair.CounterCurrency.ShouldBe(eur);
+    }
+
+    [Fact]
+    public void GivenCurrencyPair_WhenReversed_ThenPairShouldBeSwapped()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+        var pair = currencyPairFactory.Create("USD", "EUR");
+
+        var reversed = currencyPairFactory.Reverse(pair);
+
+        reversed.BaseCurrency.ShouldBe(pair.CounterCurrency);
+        reversed.CounterCurrency.ShouldBe(pair.BaseCurrency);
+    }
+
+    [Fact]
+    public void GivenInvalidIsoCurrencySymbol_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var created = currencyPairFactory.TryCreate("ZZZ", "EUR", out var pair);
+
+        created.ShouldBeFalse();
+        pair.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenInvalidIsoCurrencySymbol_WhenTryReverseCalled_ThenItShouldReturnFalse()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var reversed = currencyPairFactory.TryReverse("USD", "ZZZ", out var pair);
+
+        reversed.ShouldBeFalse();
+        pair.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenIsoCurrencySymbols_WhenCurrencyPairCreated_ThenPairShouldMatch()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var pair = currencyPairFactory.Create("USD", "EUR");
+
+        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("USD");
+        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("EUR");
+    }
+
+    [Fact]
+    public void GivenIsoCurrencySymbols_WhenReversed_ThenPairShouldBeSwapped()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var reversed = currencyPairFactory.Reverse("USD", "EUR");
+
+        reversed.BaseCurrency.ISOCurrencySymbol.ShouldBe("EUR");
+        reversed.CounterCurrency.ISOCurrencySymbol.ShouldBe("USD");
+    }
+
+    [Fact]
+    public void GivenNullCurrency_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+        CurrencyInfo currency = null;
+
+        var created = currencyPairFactory.TryCreate(currency, new CurrencyInfo("EUR"), out var pair);
+
+        created.ShouldBeFalse();
+        pair.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenRegions_WhenCurrencyPairCreated_ThenPairShouldMatch()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var pair = currencyPairFactory.Create(new RegionInfo("US"), new RegionInfo("GB"));
+
+        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("USD");
+        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("GBP");
+    }
+
+    [Fact]
+    public void GivenSameCurrencyPair_WhenCreatedTwice_ThenCachedPairShouldBeReturned()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var pair1 = currencyPairFactory.Create("USD", "EUR");
+        var pair2 = currencyPairFactory.Create("USD", "EUR");
+
+        pair2.ShouldBeSameAs(pair1);
+    }
+
+    [Fact]
+    public void GivenSameCurrency_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        var currencyPairFactory = CreateCurrencyPairFactory();
+
+        var created = currencyPairFactory.TryCreate("USD", "USD", out var pair);
+
+        created.ShouldBeFalse();
+        pair.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenServiceProvider_WhenCurrencyPairFactoryResolved_ThenItShouldNotBeNull()
+    {
+        var currencyPairFactory = CreateServiceProvider().GetRequiredService<ICurrencyPairFactory>();
+
+        _ = currencyPairFactory.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void GivenValidCountries_WhenTryReverseCalled_ThenItShouldReturnReversedPair()
+    {
+        var serviceProvider = CreateServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var currencyPairFactory = serviceProvider.GetRequiredService<ICurrencyPairFactory>();
+
+        var reversed = currencyPairFactory.TryReverse(
+            countryFactory.Create("US"),
+            countryFactory.Create("GB"),
+            out var pair);
+
+        reversed.ShouldBeTrue();
+        _ = pair.ShouldNotBeNull();
+        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("GBP");
+        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("USD");
+    }
+
+    private static ICurrencyPairFactory CreateCurrencyPairFactory()
+        => CreateServiceProvider().GetRequiredService<ICurrencyPairFactory>();
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        return services.BuildServiceProvider();
+    }
+}

--- a/TIKSN.Framework.Core.Tests/Finance/FixedRateCurrencyConverterTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/FixedRateCurrencyConverterTests.cs
@@ -21,7 +21,9 @@ public class FixedRateCurrencyConverterTests
 
         var initial = new Money(usDollar, amount: 100);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         var final = await converter.ConvertCurrencyAsync(initial, poundSterling, DateTime.Now,
             cancellationToken: TestContext.Current.CancellationToken);
@@ -43,7 +45,9 @@ public class FixedRateCurrencyConverterTests
 
         var initial = new Money(usDollar, amount: 100);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         _ = await new Func<Task>(async () =>
                 await converter.ConvertCurrencyAsync(initial, euro, DateTimeOffset.Now,
@@ -67,7 +71,9 @@ public class FixedRateCurrencyConverterTests
 
         var initial = new Money(armenianDram, amount: 100);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         _ = await new Func<Task>(async () =>
                 await converter.ConvertCurrencyAsync(initial, euro, DateTimeOffset.Now,
@@ -88,17 +94,19 @@ public class FixedRateCurrencyConverterTests
 
         _ = new CurrencyInfo(italy);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
-        ReferenceEquals(converter.CurrencyPair.BaseCurrency, usDollar).ShouldBeTrue();
-        ReferenceEquals(converter.CurrencyPair.CounterCurrency, poundSterling).ShouldBeTrue();
+        converter.CurrencyPair.BaseCurrency.ShouldBe(usDollar);
+        converter.CurrencyPair.CounterCurrency.ShouldBe(poundSterling);
         return Task.CompletedTask;
     }
 
     [Fact]
     public Task FixedRateCurrencyConverter001()
     {
-        _ = new Func<object>(() => new FixedRateCurrencyConverter(pair: null, rate: 0.5m))
+        _ = new Func<object>(() => CreateFixedRateCurrencyConverter(pair: null, rate: 0.5m))
             .ShouldThrow<ArgumentNullException>();
         return Task.CompletedTask;
     }
@@ -112,9 +120,10 @@ public class FixedRateCurrencyConverterTests
         var usDollar = new CurrencyInfo(unitedStates);
         var armenianDram = new CurrencyInfo(armenia);
 
-        var pair = new CurrencyPair(usDollar, armenianDram);
+        var pair = Helper.CurrencyPairFactory.Create(usDollar, armenianDram);
 
-        _ = new Func<object>(() => new FixedRateCurrencyConverter(pair, rate: -0.5m)).ShouldThrow<ArgumentException>();
+        _ = new Func<object>(() => CreateFixedRateCurrencyConverter(pair, rate: -0.5m))
+            .ShouldThrow<ArgumentException>();
         return Task.CompletedTask;
     }
 
@@ -127,9 +136,9 @@ public class FixedRateCurrencyConverterTests
         var usDollar = new CurrencyInfo(unitedStates);
         var poundSterling = new CurrencyInfo(unitedKingdom);
 
-        var pair = new CurrencyPair(usDollar, poundSterling);
+        var pair = Helper.CurrencyPairFactory.Create(usDollar, poundSterling);
 
-        var converter = new FixedRateCurrencyConverter(pair, rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(pair, rate: 2m);
 
         converter.CurrencyPair.BaseCurrency.ShouldBe(usDollar);
         converter.CurrencyPair.CounterCurrency.ShouldBe(poundSterling);
@@ -150,9 +159,12 @@ public class FixedRateCurrencyConverterTests
         var usDollar = new CurrencyInfo(unitedStates);
         var poundSterling = new CurrencyInfo(unitedKingdom);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
-        (await converter.GetExchangeRateAsync(new CurrencyPair(usDollar, poundSterling), DateTimeOffset.Now,
+        (await converter.GetExchangeRateAsync(Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+                DateTimeOffset.Now,
                 cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true)).ShouldBe(2m);
     }
@@ -166,10 +178,13 @@ public class FixedRateCurrencyConverterTests
         var usDollar = new CurrencyInfo(unitedStates);
         var poundSterling = new CurrencyInfo(unitedKingdom);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         _ = await new Func<Task>(async () =>
-            await converter.GetExchangeRateAsync(new CurrencyPair(poundSterling, usDollar), DateTimeOffset.Now,
+            await converter.GetExchangeRateAsync(Helper.CurrencyPairFactory.Create(poundSterling, usDollar),
+                    DateTimeOffset.Now,
                     cancellationToken: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true)).ShouldThrowAsync<ArgumentException>();
     }
@@ -185,10 +200,13 @@ public class FixedRateCurrencyConverterTests
         var poundSterling = new CurrencyInfo(unitedKingdom);
         var euro = new CurrencyInfo(italy);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         _ = await new Func<Task>(async () =>
-            await converter.GetExchangeRateAsync(new CurrencyPair(euro, usDollar), DateTimeOffset.Now,
+            await converter.GetExchangeRateAsync(Helper.CurrencyPairFactory.Create(euro, usDollar),
+                    DateTimeOffset.Now,
                     cancellationToken: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true)).ShouldThrowAsync<ArgumentException>();
     }
@@ -204,10 +222,12 @@ public class FixedRateCurrencyConverterTests
         var poundSterling = new CurrencyInfo(unitedKingdom);
         var euro = new CurrencyInfo(italy);
 
-        var converter = new FixedRateCurrencyConverter(new CurrencyPair(usDollar, poundSterling), rate: 2m);
+        var converter = CreateFixedRateCurrencyConverter(
+            Helper.CurrencyPairFactory.Create(usDollar, poundSterling),
+            rate: 2m);
 
         _ = await new Func<Task>(async () =>
-            await converter.GetExchangeRateAsync(new CurrencyPair(usDollar, euro), DateTimeOffset.Now,
+            await converter.GetExchangeRateAsync(Helper.CurrencyPairFactory.Create(usDollar, euro), DateTimeOffset.Now,
                     cancellationToken: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true)).ShouldThrowAsync<ArgumentException>();
     }
@@ -221,9 +241,9 @@ public class FixedRateCurrencyConverterTests
         var usDollar = new CurrencyInfo(unitedStates);
         var poundSterling = new CurrencyInfo(unitedKingdom);
 
-        var pair = new CurrencyPair(poundSterling, usDollar);
+        var pair = Helper.CurrencyPairFactory.Create(poundSterling, usDollar);
 
-        var converter = new FixedRateCurrencyConverter(pair, rate: 1.6m);
+        var converter = CreateFixedRateCurrencyConverter(pair, rate: 1.6m);
 
         var lastMonth = DateTimeOffset.Now.AddMonths(-1);
         var nextMonth = DateTimeOffset.Now.AddMonths(1);
@@ -235,4 +255,7 @@ public class FixedRateCurrencyConverterTests
 
         (rateInLastMonth == rateInNextMonth).ShouldBeTrue();
     }
+
+    private static FixedRateCurrencyConverter CreateFixedRateCurrencyConverter(CurrencyPair pair, decimal rate)
+        => new(pair, rate, Helper.CurrencyPairFactory);
 }

--- a/TIKSN.Framework.Core.Tests/Finance/Helper.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/Helper.cs
@@ -1,23 +1,27 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using TIKSN.DependencyInjection;
 using TIKSN.Finance;
 
 namespace TIKSN.Tests.Finance;
 
 public static class Helper
 {
+    public static ICurrencyPairFactory CurrencyPairFactory { get; } = CreateCurrencyPairFactory();
+
     public static CurrencyInfo SampleCurrency1 => new(new RegionInfo("US"));
 
     public static CurrencyInfo SampleCurrency2 => new(new RegionInfo("DE"));
 
     public static CurrencyInfo SampleCurrency3 => new(new RegionInfo("GB"));
 
-    public static CurrencyPair SampleCurrencyPair1 => new(SampleCurrency1, SampleCurrency2);
+    public static CurrencyPair SampleCurrencyPair1 => CurrencyPairFactory.Create(SampleCurrency1, SampleCurrency2);
 
-    public static CurrencyPair SampleCurrencyPair2 => new(SampleCurrency1, SampleCurrency3);
+    public static CurrencyPair SampleCurrencyPair2 => CurrencyPairFactory.Create(SampleCurrency1, SampleCurrency3);
 
-    public static CurrencyPair SampleCurrencyPair3 => new(SampleCurrency2, SampleCurrency3);
+    public static CurrencyPair SampleCurrencyPair3 => CurrencyPairFactory.Create(SampleCurrency2, SampleCurrency3);
 
     public static IEnumerable<CurrencyPair> SampleCurrencyPairs1 =>
     [
@@ -44,5 +48,12 @@ public static class Helper
         var rng = new Random();
 
         return (decimal)rng.NextDouble();
+    }
+
+    private static ICurrencyPairFactory CreateCurrencyPairFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        return services.BuildServiceProvider().GetRequiredService<ICurrencyPairFactory>();
     }
 }

--- a/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TIKSN.Framework.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using ReactiveUI;
 using Spectre.Console;
 using TIKSN.Concurrency;
 using TIKSN.FileSystem;
+using TIKSN.Finance;
 using TIKSN.Finance.ForeignExchange.Bank;
 using TIKSN.Globalization;
 using TIKSN.Identity;
@@ -38,6 +39,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ICultureFactory, CultureFactory>();
         services.TryAddSingleton<ICountryFactory, CountryFactory>();
         services.TryAddSingleton<ICurrencyFactory, CurrencyFactory>();
+        services.TryAddSingleton<ICurrencyPairFactory, CurrencyPairFactory>();
         services.TryAddSingleton<IDateTimeZoneLookup, DateTimeZoneLookup>();
         services.TryAddSingleton<ITimeZoneInfoLookup, TimeZoneInfoLookup>();
         services.TryAddSingleton<IRegionFactory, RegionFactory>();

--- a/TIKSN.Framework.Core/Finance/Cache/CachedCurrencyConverter.cs
+++ b/TIKSN.Framework.Core/Finance/Cache/CachedCurrencyConverter.cs
@@ -4,11 +4,13 @@ public class CachedCurrencyConverter : ICurrencyConverter
 {
     private readonly List<CachedCurrencyPairs> cachedCurrencyPairs;
     private readonly List<CachedRate> cachedRates;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly ICurrencyConverter originalConverter;
     private readonly TimeProvider timeProvider;
 
     public CachedCurrencyConverter(
         ICurrencyConverter originalConverter,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider,
         TimeSpan ratesCacheInterval,
         TimeSpan currencyPairsCacheInterval,
@@ -40,6 +42,7 @@ public class CachedCurrencyConverter : ICurrencyConverter
         }
 
         this.originalConverter = originalConverter ?? throw new ArgumentNullException(nameof(originalConverter));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.RatesCacheInterval = ratesCacheInterval;
         this.CurrencyPairsCacheInterval = currencyPairsCacheInterval;
         this.RatesCacheCapacity = ratesCacheCapacity;
@@ -82,7 +85,7 @@ public class CachedCurrencyConverter : ICurrencyConverter
             return new Money(counterCurrency);
         }
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var cachedRate = this.GetFromCache(this.cachedRates.Where(item => item.Pair == pair),
             this.RatesCacheInterval, asOn);

--- a/TIKSN.Framework.Core/Finance/CurrencyPairFactory.cs
+++ b/TIKSN.Framework.Core/Finance/CurrencyPairFactory.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using TIKSN.Data.Cache.Memory;
+using TIKSN.Globalization;
+
+namespace TIKSN.Finance;
+
+public class CurrencyPairFactory : MemoryCacheDecoratorBase<CurrencyPair>, ICurrencyPairFactory
+{
+    private readonly ICurrencyFactory currencyFactory;
+
+    public CurrencyPairFactory(
+        IMemoryCache memoryCache,
+        ICurrencyFactory currencyFactory,
+        IOptions<MemoryCacheDecoratorOptions> genericOptions,
+        IOptions<MemoryCacheDecoratorOptions<CurrencyPair>> specificOptions) : base(
+        memoryCache,
+        genericOptions,
+        specificOptions) => this.currencyFactory =
+        currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+
+    public CurrencyPair Create(CurrencyInfo baseCurrency, CurrencyInfo counterCurrency)
+    {
+        ArgumentNullException.ThrowIfNull(baseCurrency);
+        ArgumentNullException.ThrowIfNull(counterCurrency);
+
+        var cacheKey = Tuple.Create(
+            EntityType,
+            baseCurrency.ISOCurrencySymbol,
+            counterCurrency.ISOCurrencySymbol);
+
+        return this.GetFromMemoryCache(cacheKey, () => new CurrencyPair(baseCurrency, counterCurrency))
+            ?? throw new InvalidOperationException("Failed to create CurrencyPair.");
+    }
+
+    public CurrencyPair Create(string baseIsoCurrencySymbol, string counterIsoCurrencySymbol)
+        => this.Create(
+            this.currencyFactory.Create(baseIsoCurrencySymbol),
+            this.currencyFactory.Create(counterIsoCurrencySymbol));
+
+    public CurrencyPair Create(RegionInfo baseRegion, RegionInfo counterRegion)
+        => this.Create(
+            this.currencyFactory.Create(baseRegion),
+            this.currencyFactory.Create(counterRegion));
+
+    public CurrencyPair Create(CountryInfo baseCountry, CountryInfo counterCountry)
+    {
+        ArgumentNullException.ThrowIfNull(baseCountry);
+        ArgumentNullException.ThrowIfNull(counterCountry);
+
+        return this.Create(baseCountry.PrincipalRegion, counterCountry.PrincipalRegion);
+    }
+
+    public CurrencyPair Reverse(CurrencyPair pair)
+    {
+        ArgumentNullException.ThrowIfNull(pair);
+
+        return this.Create(pair.CounterCurrency, pair.BaseCurrency);
+    }
+
+    public CurrencyPair Reverse(CurrencyInfo baseCurrency, CurrencyInfo counterCurrency)
+    {
+        var reversedBaseCurrency = counterCurrency;
+        var reversedCounterCurrency = baseCurrency;
+
+        return this.Create(reversedBaseCurrency, reversedCounterCurrency);
+    }
+
+    public CurrencyPair Reverse(string baseIsoCurrencySymbol, string counterIsoCurrencySymbol)
+    {
+        var reversedBaseIsoCurrencySymbol = counterIsoCurrencySymbol;
+        var reversedCounterIsoCurrencySymbol = baseIsoCurrencySymbol;
+
+        return this.Create(reversedBaseIsoCurrencySymbol, reversedCounterIsoCurrencySymbol);
+    }
+
+    public CurrencyPair Reverse(RegionInfo baseRegion, RegionInfo counterRegion)
+    {
+        var reversedBaseRegion = counterRegion;
+        var reversedCounterRegion = baseRegion;
+
+        return this.Create(reversedBaseRegion, reversedCounterRegion);
+    }
+
+    public CurrencyPair Reverse(CountryInfo baseCountry, CountryInfo counterCountry)
+    {
+        var reversedBaseCountry = counterCountry;
+        var reversedCounterCountry = baseCountry;
+
+        return this.Create(reversedBaseCountry, reversedCounterCountry);
+    }
+
+    public bool TryCreate(
+        CurrencyInfo baseCurrency,
+        CurrencyInfo counterCurrency,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Create(baseCurrency, counterCurrency), out pair);
+
+    public bool TryCreate(
+        string baseIsoCurrencySymbol,
+        string counterIsoCurrencySymbol,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Create(baseIsoCurrencySymbol, counterIsoCurrencySymbol), out pair);
+
+    public bool TryCreate(
+        RegionInfo baseRegion,
+        RegionInfo counterRegion,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Create(baseRegion, counterRegion), out pair);
+
+    public bool TryCreate(
+        CountryInfo baseCountry,
+        CountryInfo counterCountry,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Create(baseCountry, counterCountry), out pair);
+
+    public bool TryReverse(CurrencyPair pair, [NotNullWhen(true)] out CurrencyPair? pairReversed)
+        => TryCreateCore(() => this.Reverse(pair), out pairReversed);
+
+    public bool TryReverse(
+        CurrencyInfo baseCurrency,
+        CurrencyInfo counterCurrency,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Reverse(baseCurrency, counterCurrency), out pair);
+
+    public bool TryReverse(
+        string baseIsoCurrencySymbol,
+        string counterIsoCurrencySymbol,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Reverse(baseIsoCurrencySymbol, counterIsoCurrencySymbol), out pair);
+
+    public bool TryReverse(
+        RegionInfo baseRegion,
+        RegionInfo counterRegion,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Reverse(baseRegion, counterRegion), out pair);
+
+    public bool TryReverse(
+        CountryInfo baseCountry,
+        CountryInfo counterCountry,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+        => TryCreateCore(() => this.Reverse(baseCountry, counterCountry), out pair);
+
+    private static bool TryCreateCore(
+        Func<CurrencyPair> pairFactory,
+        [NotNullWhen(true)] out CurrencyPair? pair)
+    {
+        try
+        {
+            pair = pairFactory();
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            pair = null;
+            return false;
+        }
+        catch (CurrencyNotFoundException)
+        {
+            pair = null;
+            return false;
+        }
+    }
+}

--- a/TIKSN.Framework.Core/Finance/FixedRateCurrencyConverter.cs
+++ b/TIKSN.Framework.Core/Finance/FixedRateCurrencyConverter.cs
@@ -2,11 +2,13 @@ namespace TIKSN.Finance;
 
 public class FixedRateCurrencyConverter : ICurrencyConverter
 {
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly decimal rate;
 
-    public FixedRateCurrencyConverter(CurrencyPair pair, decimal rate)
+    public FixedRateCurrencyConverter(CurrencyPair pair, decimal rate, ICurrencyPairFactory currencyPairFactory)
     {
         this.CurrencyPair = pair ?? throw new ArgumentNullException(nameof(pair));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
 
         if (rate > decimal.Zero)
         {
@@ -29,7 +31,7 @@ public class FixedRateCurrencyConverter : ICurrencyConverter
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var requiredPair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var requiredPair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         if (this.CurrencyPair == requiredPair)
         {

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfCanada.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfCanada.cs
@@ -19,6 +19,7 @@ public class BankOfCanada : IBankOfCanada
         new("https://www.bankofcanada.ca/valet/observations/group/FX_RATES_DAILY/json");
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly Dictionary<DateOnly, Dictionary<CurrencyInfo, decimal>> rates;
     private readonly TimeProvider timeProvider;
@@ -27,6 +28,7 @@ public class BankOfCanada : IBankOfCanada
     public BankOfCanada(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.rates = [];
@@ -34,6 +36,7 @@ public class BankOfCanada : IBankOfCanada
         this.lastFetchDate = DateTimeOffset.MinValue;
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -45,7 +48,7 @@ public class BankOfCanada : IBankOfCanada
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
@@ -67,8 +70,8 @@ public class BankOfCanada : IBankOfCanada
 
         foreach (var against in this.GetRatesByDate(asOn).Keys)
         {
-            result.Add(new CurrencyPair(CanadianDollar, against));
-            result.Add(new CurrencyPair(against, CanadianDollar));
+            result.Add(this.currencyPairFactory.Create(CanadianDollar, against));
+            result.Add(this.currencyPairFactory.Create(against, CanadianDollar));
         }
 
         return result;
@@ -113,7 +116,7 @@ public class BankOfCanada : IBankOfCanada
 
             if (asOnDate == rawItem.Item2)
             {
-                result.Add(new ExchangeRate(new CurrencyPair(currency, CanadianDollar),
+                result.Add(new ExchangeRate(this.currencyPairFactory.Create(currency, CanadianDollar),
                     GetRateDateTimeOffset(rawItem.Item2), rawItem.Item3));
             }
 

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfEngland.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfEngland.cs
@@ -9,26 +9,28 @@ public class BankOfEngland : IBankOfEngland
     private static readonly Dictionary<Uri, IReadOnlyList<ExchangeRate>> ExchangeRatesCache = [];
     private static readonly SemaphoreSlim ExchangeRatesSemaphore = new(initialCount: 1, maxCount: 1);
 
-    private static readonly (Dictionary<CurrencyPair, string>, Dictionary<string, CurrencyPair>) SeriesCodesMaps =
-        CreateSeriesCodesMaps();
-
     private static readonly CompositeFormat UrlFormat =
         CompositeFormat.Parse(
             "https://www.bankofengland.co.uk/boeapps/database/_iadb-fromshowcolumns.asp?CodeVer=new&xml.x=yes&Datefrom={0}&Dateto={1}&SeriesCodes={2}&VPD=Y&VFD=N");
 
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
+    private readonly (Dictionary<CurrencyPair, string>, Dictionary<string, CurrencyPair>) seriesCodesMaps;
     private readonly TimeProvider timeProvider;
 
     public BankOfEngland(
         HttpClient httpClient,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
+        this.seriesCodesMaps = CreateSeriesCodesMaps(this.currencyPairFactory);
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
-    private static Dictionary<string, CurrencyPair> Pairs => SeriesCodesMaps.Item2;
-    private static Dictionary<CurrencyPair, string> SeriesCodes => SeriesCodesMaps.Item1;
+    private Dictionary<string, CurrencyPair> Pairs => this.seriesCodesMaps.Item2;
+    private Dictionary<CurrencyPair, string> SeriesCodes => this.seriesCodesMaps.Item1;
 
     public async Task<Money> ConvertCurrencyAsync(
         Money baseMoney,
@@ -52,10 +54,10 @@ public class BankOfEngland : IBankOfEngland
     {
         var pairs = new List<CurrencyPair>();
 
-        foreach (var pair in SeriesCodes.Keys)
+        foreach (var pair in this.SeriesCodes.Keys)
         {
             var rates = await this.GetSeriesCodeExchangeRateAsync(
-                SeriesCodes[pair],
+                this.SeriesCodes[pair],
                 asOn,
                 cancellationToken).ConfigureAwait(false);
 
@@ -98,11 +100,11 @@ public class BankOfEngland : IBankOfEngland
         }
 
         string seriesCode;
-        var pair = new CurrencyPair(baseCurrency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseCurrency, counterCurrency);
 
         try
         {
-            seriesCode = SeriesCodes[pair];
+            seriesCode = this.SeriesCodes[pair];
         }
         catch (KeyNotFoundException)
         {
@@ -126,7 +128,7 @@ public class BankOfEngland : IBankOfEngland
         CancellationToken cancellationToken)
     {
         List<ExchangeRate> rates = [];
-        foreach (var seriesCode in SeriesCodes)
+        foreach (var seriesCode in this.SeriesCodes)
         {
             var exchangeRates = await this.GetSeriesCodeExchangeRateAsync(seriesCode.Value, asOn, cancellationToken)
                 .ConfigureAwait(false);
@@ -138,6 +140,7 @@ public class BankOfEngland : IBankOfEngland
 
     private static void AddSeriesCode(
         List<(CurrencyPair pair, string serieCode)> codes,
+        ICurrencyPairFactory currencyPairFactory,
         string baseCountryCode,
         string counterCountryCode,
         string serieCode)
@@ -148,93 +151,94 @@ public class BankOfEngland : IBankOfEngland
         var baseCurrency = new CurrencyInfo(baseCountry);
         var counterCurrency = new CurrencyInfo(counterCountry);
 
-        var pair = new CurrencyPair(baseCurrency, counterCurrency);
+        var pair = currencyPairFactory.Create(baseCurrency, counterCurrency);
 
         codes.Add((pair, serieCode));
     }
 
 #pragma warning disable MA0051 // Method is too long
 
-    private static (Dictionary<CurrencyPair, string>, Dictionary<string, CurrencyPair>) CreateSeriesCodesMaps()
+    private static (Dictionary<CurrencyPair, string>, Dictionary<string, CurrencyPair>) CreateSeriesCodesMaps(
+        ICurrencyPairFactory currencyPairFactory)
 #pragma warning restore MA0051 // Method is too long
     {
         List<(CurrencyPair pair, string serieCode)> codes = [];
 
-        AddSeriesCode(codes, "en-AU", "en-US", "XUDLADD");
-        AddSeriesCode(codes, "en-AU", "en-GB", "XUDLADS");
+        AddSeriesCode(codes, currencyPairFactory, "en-AU", "en-US", "XUDLADD");
+        AddSeriesCode(codes, currencyPairFactory, "en-AU", "en-GB", "XUDLADS");
 
-        AddSeriesCode(codes, "en-CA", "en-GB", "XUDLCDS");
+        AddSeriesCode(codes, currencyPairFactory, "en-CA", "en-GB", "XUDLCDS");
 
-        AddSeriesCode(codes, "zh-CN", "en-US", "XUDLBK73");
+        AddSeriesCode(codes, currencyPairFactory, "zh-CN", "en-US", "XUDLBK73");
 
-        AddSeriesCode(codes, "cs-CZ", "en-US", "XUDLBK27");
-        AddSeriesCode(codes, "cs-CZ", "en-GB", "XUDLBK25");
+        AddSeriesCode(codes, currencyPairFactory, "cs-CZ", "en-US", "XUDLBK27");
+        AddSeriesCode(codes, currencyPairFactory, "cs-CZ", "en-GB", "XUDLBK25");
 
-        AddSeriesCode(codes, "da-DK", "en-US", "XUDLDKD");
-        AddSeriesCode(codes, "da-DK", "en-GB", "XUDLDKS");
+        AddSeriesCode(codes, currencyPairFactory, "da-DK", "en-US", "XUDLDKD");
+        AddSeriesCode(codes, currencyPairFactory, "da-DK", "en-GB", "XUDLDKS");
 
-        AddSeriesCode(codes, "de-DE", "en-US", "XUDLERD");
-        AddSeriesCode(codes, "de-DE", "en-GB", "XUDLERS");
+        AddSeriesCode(codes, currencyPairFactory, "de-DE", "en-US", "XUDLERD");
+        AddSeriesCode(codes, currencyPairFactory, "de-DE", "en-GB", "XUDLERS");
 
-        AddSeriesCode(codes, "zh-HK", "en-US", "XUDLHDD");
-        AddSeriesCode(codes, "zh-HK", "en-GB", "XUDLHDS");
+        AddSeriesCode(codes, currencyPairFactory, "zh-HK", "en-US", "XUDLHDD");
+        AddSeriesCode(codes, currencyPairFactory, "zh-HK", "en-GB", "XUDLHDS");
 
-        AddSeriesCode(codes, "hu-HU", "en-US", "XUDLBK35");
-        AddSeriesCode(codes, "hu-HU", "en-GB", "XUDLBK33");
+        AddSeriesCode(codes, currencyPairFactory, "hu-HU", "en-US", "XUDLBK35");
+        AddSeriesCode(codes, currencyPairFactory, "hu-HU", "en-GB", "XUDLBK33");
 
-        AddSeriesCode(codes, "hi-IN", "en-GB", "XUDLBK97");
-        AddSeriesCode(codes, "hi-IN", "en-US", "XUDLBK64");
+        AddSeriesCode(codes, currencyPairFactory, "hi-IN", "en-GB", "XUDLBK97");
+        AddSeriesCode(codes, currencyPairFactory, "hi-IN", "en-US", "XUDLBK64");
 
-        AddSeriesCode(codes, "he-IL", "en-GB", "XUDLBK78");
-        AddSeriesCode(codes, "he-IL", "en-US", "XUDLBK65");
+        AddSeriesCode(codes, currencyPairFactory, "he-IL", "en-GB", "XUDLBK78");
+        AddSeriesCode(codes, currencyPairFactory, "he-IL", "en-US", "XUDLBK65");
 
-        AddSeriesCode(codes, "ja-JP", "en-US", "XUDLJYD");
-        AddSeriesCode(codes, "ja-JP", "en-GB", "XUDLJYS");
+        AddSeriesCode(codes, currencyPairFactory, "ja-JP", "en-US", "XUDLJYD");
+        AddSeriesCode(codes, currencyPairFactory, "ja-JP", "en-GB", "XUDLJYS");
 
-        AddSeriesCode(codes, "ms-MY", "en-GB", "XUDLBK83");
-        AddSeriesCode(codes, "ms-MY", "en-US", "XUDLBK66");
+        AddSeriesCode(codes, currencyPairFactory, "ms-MY", "en-GB", "XUDLBK83");
+        AddSeriesCode(codes, currencyPairFactory, "ms-MY", "en-US", "XUDLBK66");
 
-        AddSeriesCode(codes, "en-NZ", "en-US", "XUDLNDD");
-        AddSeriesCode(codes, "en-NZ", "en-GB", "XUDLNDS");
+        AddSeriesCode(codes, currencyPairFactory, "en-NZ", "en-US", "XUDLNDD");
+        AddSeriesCode(codes, currencyPairFactory, "en-NZ", "en-GB", "XUDLNDS");
 
-        AddSeriesCode(codes, "nn-NO", "en-US", "XUDLNKD");
-        AddSeriesCode(codes, "nn-NO", "en-GB", "XUDLNKS");
+        AddSeriesCode(codes, currencyPairFactory, "nn-NO", "en-US", "XUDLNKD");
+        AddSeriesCode(codes, currencyPairFactory, "nn-NO", "en-GB", "XUDLNKS");
 
-        AddSeriesCode(codes, "pl-PL", "en-US", "XUDLBK49");
-        AddSeriesCode(codes, "pl-PL", "en-GB", "XUDLBK47");
+        AddSeriesCode(codes, currencyPairFactory, "pl-PL", "en-US", "XUDLBK49");
+        AddSeriesCode(codes, currencyPairFactory, "pl-PL", "en-GB", "XUDLBK47");
 
-        AddSeriesCode(codes, "ar-SA", "en-US", "XUDLSRD");
-        AddSeriesCode(codes, "ar-SA", "en-GB", "XUDLSRS");
+        AddSeriesCode(codes, currencyPairFactory, "ar-SA", "en-US", "XUDLSRD");
+        AddSeriesCode(codes, currencyPairFactory, "ar-SA", "en-GB", "XUDLSRS");
 
-        AddSeriesCode(codes, "zh-SG", "en-US", "XUDLSGD");
-        AddSeriesCode(codes, "zh-SG", "en-GB", "XUDLSGS");
+        AddSeriesCode(codes, currencyPairFactory, "zh-SG", "en-US", "XUDLSGD");
+        AddSeriesCode(codes, currencyPairFactory, "zh-SG", "en-GB", "XUDLSGS");
 
-        AddSeriesCode(codes, "af-ZA", "en-US", "XUDLZRD");
-        AddSeriesCode(codes, "af-ZA", "en-GB", "XUDLZRS");
+        AddSeriesCode(codes, currencyPairFactory, "af-ZA", "en-US", "XUDLZRD");
+        AddSeriesCode(codes, currencyPairFactory, "af-ZA", "en-GB", "XUDLZRS");
 
-        AddSeriesCode(codes, "ko-KR", "en-GB", "XUDLBK93");
-        AddSeriesCode(codes, "ko-KR", "en-US", "XUDLBK74");
+        AddSeriesCode(codes, currencyPairFactory, "ko-KR", "en-GB", "XUDLBK93");
+        AddSeriesCode(codes, currencyPairFactory, "ko-KR", "en-US", "XUDLBK74");
 
-        AddSeriesCode(codes, "en-GB", "en-US", "XUDLGBD");
+        AddSeriesCode(codes, currencyPairFactory, "en-GB", "en-US", "XUDLGBD");
 
-        AddSeriesCode(codes, "se-SE", "en-US", "XUDLSKD");
-        AddSeriesCode(codes, "se-SE", "en-GB", "XUDLSKS");
+        AddSeriesCode(codes, currencyPairFactory, "se-SE", "en-US", "XUDLSKD");
+        AddSeriesCode(codes, currencyPairFactory, "se-SE", "en-GB", "XUDLSKS");
 
-        AddSeriesCode(codes, "de-CH", "en-US", "XUDLSFD");
-        AddSeriesCode(codes, "de-CH", "en-GB", "XUDLSFS");
+        AddSeriesCode(codes, currencyPairFactory, "de-CH", "en-US", "XUDLSFD");
+        AddSeriesCode(codes, currencyPairFactory, "de-CH", "en-GB", "XUDLSFS");
 
-        AddSeriesCode(codes, "zh-TW", "en-US", "XUDLTWD");
-        AddSeriesCode(codes, "zh-TW", "en-GB", "XUDLTWS");
+        AddSeriesCode(codes, currencyPairFactory, "zh-TW", "en-US", "XUDLTWD");
+        AddSeriesCode(codes, currencyPairFactory, "zh-TW", "en-GB", "XUDLTWS");
 
-        AddSeriesCode(codes, "th-TH", "en-GB", "XUDLBK87");
-        AddSeriesCode(codes, "th-TH", "en-US", "XUDLBK72");
+        AddSeriesCode(codes, currencyPairFactory, "th-TH", "en-GB", "XUDLBK87");
+        AddSeriesCode(codes, currencyPairFactory, "th-TH", "en-US", "XUDLBK72");
 
-        AddSeriesCode(codes, "tr-TR", "en-GB", "XUDLBK95");
-        AddSeriesCode(codes, "tr-TR", "en-US", "XUDLBK75");
+        AddSeriesCode(codes, currencyPairFactory, "tr-TR", "en-GB", "XUDLBK95");
+        AddSeriesCode(codes, currencyPairFactory, "tr-TR", "en-US", "XUDLBK75");
 
-        AddSeriesCode(codes, "en-US", "en-GB", "XUDLUSS");
+        AddSeriesCode(codes, currencyPairFactory, "en-US", "en-GB", "XUDLUSS");
 
-        AddSeriesCode(codes, "zh-CN", "en-GB", "XUDLBK89");
+        AddSeriesCode(codes, currencyPairFactory, "zh-CN", "en-GB", "XUDLBK89");
 
         return ValueTuple.Create(
             codes.ToDictionary(k => k.pair, v => v.serieCode),
@@ -284,7 +288,7 @@ public class BankOfEngland : IBankOfEngland
         Uri requestUrl,
         CancellationToken cancellationToken)
     {
-        var pair = Pairs[seriesCode];
+        var pair = this.Pairs[seriesCode];
 
         var responseStream = await this.httpClient.GetStreamAsync(requestUrl, cancellationToken).ConfigureAwait(false);
         XDocument xdoc;
@@ -316,7 +320,7 @@ public class BankOfEngland : IBankOfEngland
                     var rate = decimal.One / reverseRate;
 
                     rates.Add(new ExchangeRate(pair, itemTime, rate));
-                    rates.Add(new ExchangeRate(pair.Reverse(), itemTime, reverseRate));
+                    rates.Add(new ExchangeRate(this.currencyPairFactory.Reverse(pair), itemTime, reverseRate));
                 }
             }
         }

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfRussia.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/BankOfRussia.cs
@@ -18,6 +18,7 @@ public class BankOfRussia : IBankOfRussia
     private static readonly CurrencyInfo RussianRuble = new(new RegionInfo("ru-RU"));
     private static readonly CultureInfo RussianRussia = new("ru-RU");
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly Dictionary<CurrencyInfo, decimal> rates;
     private readonly TimeProvider timeProvider;
@@ -26,12 +27,14 @@ public class BankOfRussia : IBankOfRussia
     public BankOfRussia(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.rates = [];
         this.published = null;
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -61,8 +64,8 @@ public class BankOfRussia : IBankOfRussia
 
         foreach (var foreignCurrency in this.rates.Keys)
         {
-            pairs.Add(new CurrencyPair(foreignCurrency, RussianRuble));
-            pairs.Add(new CurrencyPair(RussianRuble, foreignCurrency));
+            pairs.Add(this.currencyPairFactory.Create(foreignCurrency, RussianRuble));
+            pairs.Add(this.currencyPairFactory.Create(RussianRuble, foreignCurrency));
         }
 
         return pairs;
@@ -193,9 +196,9 @@ public class BankOfRussia : IBankOfRussia
             {
                 var currency = this.currencyFactory.Create(publishedRate.CurrencyCode);
 
-                result.Add(new ExchangeRate(new CurrencyPair(currency, RussianRuble), asOn,
+                result.Add(new ExchangeRate(this.currencyPairFactory.Create(currency, RussianRuble), asOn,
                     publishedRate.Rate));
-                result.Add(new ExchangeRate(new CurrencyPair(RussianRuble, currency), asOn,
+                result.Add(new ExchangeRate(this.currencyPairFactory.Create(RussianRuble, currency), asOn,
                     decimal.One / publishedRate.Rate));
 
                 this.rates.Add(currency, publishedRate.Rate);

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/CentralBankOfArmenia.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/CentralBankOfArmenia.cs
@@ -14,6 +14,7 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
         new("https://old.cba.am/_layouts/rssreader.aspx?rss=280F57B8-763C-4EE4-90E0-8136C13E47DA");
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly Dictionary<CurrencyInfo, decimal> oneWayRates;
     private readonly TimeProvider timeProvider;
@@ -23,6 +24,7 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
     public CentralBankOfArmenia(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.oneWayRates = [];
@@ -30,6 +32,7 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
         this.lastFetchDate = DateTimeOffset.MinValue;
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -42,7 +45,7 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
@@ -59,8 +62,8 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
 
         foreach (var rateCurrency in this.oneWayRates.Select(x => x.Key))
         {
-            rates.Add(new CurrencyPair(rateCurrency, AMD));
-            rates.Add(new CurrencyPair(AMD, rateCurrency));
+            rates.Add(this.currencyPairFactory.Create(rateCurrency, AMD));
+            rates.Add(this.currencyPairFactory.Create(AMD, rateCurrency));
         }
 
         return rates;
@@ -139,8 +142,8 @@ public class CentralBankOfArmenia : ICentralBankOfArmenia
 
                     var currency = this.currencyFactory.Create(currencyCode);
                     this.oneWayRates[currency] = rate;
-                    result.Add(new ExchangeRate(new CurrencyPair(AMD, currency), publishedAt, rate));
-                    result.Add(new ExchangeRate(new CurrencyPair(currency, AMD), publishedAt,
+                    result.Add(new ExchangeRate(this.currencyPairFactory.Create(AMD, currency), publishedAt, rate));
+                    result.Add(new ExchangeRate(this.currencyPairFactory.Create(currency, AMD), publishedAt,
                         baseUnit / counterUnit));
                 }
 

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/EuropeanCentralBank.cs
@@ -22,16 +22,19 @@ public class EuropeanCentralBank : IEuropeanCentralBank
 
     private static readonly Uri Since1999RatesUrl = new("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml");
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly TimeProvider timeProvider;
 
     public EuropeanCentralBank(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -44,7 +47,7 @@ public class EuropeanCentralBank : IEuropeanCentralBank
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
         return new Money(counterCurrency, baseMoney.Amount * rate);
@@ -63,7 +66,7 @@ public class EuropeanCentralBank : IEuropeanCentralBank
         foreach (var pair in rates.Select(x => x.Pair))
         {
             result.Add(pair);
-            result.Add(new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency));
+            result.Add(this.currencyPairFactory.Reverse(pair));
         }
 
         return result;
@@ -86,7 +89,7 @@ public class EuropeanCentralBank : IEuropeanCentralBank
             return rate.Rate;
         }
 
-        var reverseRate = rates.SingleOrDefault(item => item.Pair.Reverse() == pair);
+        var reverseRate = rates.SingleOrDefault(item => this.currencyPairFactory.Reverse(item.Pair) == pair);
         if (reverseRate != null)
         {
             return reverseRate.Reverse().Rate;
@@ -126,7 +129,7 @@ public class EuropeanCentralBank : IEuropeanCentralBank
             var currencyCode = rateCube?.Attribute("currency")?.Value ?? string.Empty;
             var rate = decimal.Parse(rateCube?.Attribute("rate")?.Value ?? string.Empty, CultureInfo.InvariantCulture);
 
-            rates.Add(new ExchangeRate(new CurrencyPair(Euro, this.currencyFactory.Create(currencyCode)),
+            rates.Add(new ExchangeRate(this.currencyPairFactory.Create(Euro, this.currencyFactory.Create(currencyCode)),
                 CreateEuropeanCentralBankDateTimeOffset(groupCubes.Item2), rate));
         }
 

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/FederalReserveSystem.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/FederalReserveSystem.cs
@@ -17,16 +17,19 @@ public class FederalReserveSystem : IFederalReserveSystem
     private static readonly TimeZoneInfo FederalReserveTimeZone = FindFederalReserveTimeZone();
     private static readonly CurrencyInfo UnitedStatesDollar = new(new RegionInfo("en-US"));
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly TimeProvider timeProvider;
 
     public FederalReserveSystem(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -39,7 +42,7 @@ public class FederalReserveSystem : IFederalReserveSystem
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
@@ -58,8 +61,8 @@ public class FederalReserveSystem : IFederalReserveSystem
 
         foreach (var someCurrency in rates.Keys)
         {
-            result.Add(new CurrencyPair(UnitedStatesDollar, someCurrency));
-            result.Add(new CurrencyPair(someCurrency, UnitedStatesDollar));
+            result.Add(this.currencyPairFactory.Create(UnitedStatesDollar, someCurrency));
+            result.Add(this.currencyPairFactory.Create(someCurrency, UnitedStatesDollar));
         }
 
         return result;
@@ -226,18 +229,23 @@ public class FederalReserveSystem : IFederalReserveSystem
                     if (string.Equals(fx, "ZAL", StringComparison.Ordinal))
                     {
                         result.Add(new ExchangeRate(
-                            new CurrencyPair(UnitedStatesDollar, this.currencyFactory.Create(currencyCode)), date,
+                            this.currencyPairFactory.Create(UnitedStatesDollar,
+                                this.currencyFactory.Create(currencyCode)), date,
                             rate));
                     }
                     else if (string.Equals(fx, "VEB", StringComparison.Ordinal))
                     {
                         result.Add(new ExchangeRate(
-                            new CurrencyPair(UnitedStatesDollar, this.currencyFactory.Create("VEF")), date, rate));
+                            this.currencyPairFactory.Create(UnitedStatesDollar, this.currencyFactory.Create("VEF")),
+                            date,
+                            rate));
                     }
                     else
                     {
                         result.Add(new ExchangeRate(
-                            new CurrencyPair(UnitedStatesDollar, this.currencyFactory.Create(fx)), date, rate));
+                            this.currencyPairFactory.Create(UnitedStatesDollar, this.currencyFactory.Create(fx)),
+                            date,
+                            rate));
                     }
                 }
             }

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingapore.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingapore.cs
@@ -46,6 +46,7 @@ public class MonetaryAuthorityOfSingapore : IMonetaryAuthorityOfSingapore
     private static readonly DateTimeZone SingaporeTimeZone = DateTimeZoneProviders.Tzdb["Asia/Singapore"];
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly TimeProvider timeProvider;
     private IReadOnlyCollection<ExchangeRate>? cachedRates;
@@ -54,10 +55,12 @@ public class MonetaryAuthorityOfSingapore : IMonetaryAuthorityOfSingapore
     public MonetaryAuthorityOfSingapore(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         this.lastFetchDate = DateTimeOffset.MinValue;
     }
@@ -71,7 +74,7 @@ public class MonetaryAuthorityOfSingapore : IMonetaryAuthorityOfSingapore
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
         return new Money(counterCurrency, baseMoney.Amount * rate);
@@ -177,10 +180,10 @@ public class MonetaryAuthorityOfSingapore : IMonetaryAuthorityOfSingapore
 
         var currency = this.currencyFactory.Create(series.CurrencyCode);
         var rate = rawRate / series.Units;
-        var exchangeRate = new ExchangeRate(new CurrencyPair(currency, SingaporeDollar), asOn, rate);
+        var exchangeRate = new ExchangeRate(this.currencyPairFactory.Create(currency, SingaporeDollar), asOn, rate);
 
         rates.Add(exchangeRate);
-        rates.Add(exchangeRate.Reverse());
+        rates.Add(new ExchangeRate(this.currencyPairFactory.Reverse(exchangeRate.Pair), asOn, decimal.One / rate));
     }
 
     private async Task<IReadOnlyCollection<ExchangeRate>> FetchRatesAsync(CancellationToken cancellationToken)

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/NationalBankOfPoland.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/NationalBankOfPoland.cs
@@ -32,14 +32,17 @@ public class NationalBankOfPoland : INationalBankOfPoland
         CompositeFormat.Parse("https://api.nbp.pl/api/exchangerates/tables/{0}/{1:yyyy-MM-dd}/{2:yyyy-MM-dd}");
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
 
     public NationalBankOfPoland(
         HttpClient httpClient,
-        ICurrencyFactory currencyFactory)
+        ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
     }
 
     public async Task<Money> ConvertCurrencyAsync(
@@ -108,7 +111,7 @@ public class NationalBankOfPoland : INationalBankOfPoland
     private ExchangeRate CreateExchangeRate(ValueTuple<DateTimeOffset, Rate> entry)
     {
         var currency = this.currencyFactory.Create(entry.Item2.Code);
-        var pair = new CurrencyPair(currency, PolishZloty);
+        var pair = this.currencyPairFactory.Create(currency, PolishZloty);
         return new ExchangeRate(pair, entry.Item1, entry.Item2.Mid);
     }
 
@@ -155,7 +158,7 @@ public class NationalBankOfPoland : INationalBankOfPoland
             .. ratesA.Concat(ratesB).SelectMany(x => new[]
             {
                 x,
-                new ExchangeRate(x.Pair.Reverse(), x.AsOn, 1m / x.Rate),
+                new ExchangeRate(this.currencyPairFactory.Reverse(x.Pair), x.AsOn, 1m / x.Rate),
             }),
         ];
     }

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/NationalBankOfUkraine.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/NationalBankOfUkraine.cs
@@ -25,14 +25,17 @@ public class NationalBankOfUkraine : INationalBankOfUkraine
         CompositeFormat.Parse("https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?date={0:yyyyMMdd}");
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
 
     public NationalBankOfUkraine(
         HttpClient httpClient,
-        ICurrencyFactory currencyFactory)
+        ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory)
     {
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
     }
 
     /// <summary>
@@ -192,10 +195,10 @@ public class NationalBankOfUkraine : INationalBankOfUkraine
             if (!string.IsNullOrEmpty(currencyCode))
             {
                 _ = result.Add(new ExchangeRate(
-                    new CurrencyPair(this.currencyFactory.Create(currencyCode), UkrainianHryvnia), asOn,
+                    this.currencyPairFactory.Create(this.currencyFactory.Create(currencyCode), UkrainianHryvnia), asOn,
                     rate));
                 _ = result.Add(new ExchangeRate(
-                    new CurrencyPair(UkrainianHryvnia, this.currencyFactory.Create(currencyCode)), asOn,
+                    this.currencyPairFactory.Create(UkrainianHryvnia, this.currencyFactory.Create(currencyCode)), asOn,
                     decimal.One / rate));
             }
         }

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/ReserveBankOfAustralia.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/ReserveBankOfAustralia.cs
@@ -14,6 +14,7 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
     private static readonly SemaphoreSlim ExchangeRateDocumentSemaphore = new(initialCount: 1, maxCount: 1);
     private static readonly Uri RssUrl = new(RSS);
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly HttpClient httpClient;
     private readonly Dictionary<CurrencyInfo, decimal> rates;
     private readonly TimeProvider timeProvider;
@@ -23,6 +24,7 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
     public ReserveBankOfAustralia(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.publishedDate = DateTimeOffset.MinValue;
@@ -30,6 +32,7 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
         this.lastFetchDate = DateTimeOffset.MinValue;
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -42,7 +45,7 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(pair, asOn, cancellationToken).ConfigureAwait(false);
 
@@ -59,8 +62,8 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
 
         var pairs = new List<CurrencyPair>();
 
-        pairs.AddRange(this.rates.Keys.Select(r => new CurrencyPair(AustralianDollar, r)));
-        pairs.AddRange(this.rates.Keys.Select(r => new CurrencyPair(r, AustralianDollar)));
+        pairs.AddRange(this.rates.Keys.Select(r => this.currencyPairFactory.Create(AustralianDollar, r)));
+        pairs.AddRange(this.rates.Keys.Select(r => this.currencyPairFactory.Create(r, AustralianDollar)));
 
         return pairs;
     }
@@ -186,7 +189,7 @@ public class ReserveBankOfAustralia : IReserveBankOfAustralia
 
             this.publishedDate = period;
 
-            result.Add(new ExchangeRate(new CurrencyPair(AustralianDollar, foreignCurrency), period,
+            result.Add(new ExchangeRate(this.currencyPairFactory.Create(AustralianDollar, foreignCurrency), period,
                 exchangeRate));
         }
     }

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/SwissNationalBank.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/Bank/SwissNationalBank.cs
@@ -15,6 +15,7 @@ public class SwissNationalBank : ISwissNationalBank
 
 
     private readonly ICurrencyFactory currencyFactory;
+    private readonly ICurrencyPairFactory currencyPairFactory;
     private readonly Dictionary<CurrencyInfo, Tuple<DateTimeOffset, decimal>> foreignRates;
     private readonly HttpClient httpClient;
     private readonly TimeProvider timeProvider;
@@ -22,11 +23,13 @@ public class SwissNationalBank : ISwissNationalBank
     public SwissNationalBank(
         HttpClient httpClient,
         ICurrencyFactory currencyFactory,
+        ICurrencyPairFactory currencyPairFactory,
         TimeProvider timeProvider)
     {
         this.foreignRates = [];
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         this.currencyFactory = currencyFactory ?? throw new ArgumentNullException(nameof(currencyFactory));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
@@ -56,8 +59,8 @@ public class SwissNationalBank : ISwissNationalBank
 
         foreach (var currency in this.FilterByDate(asOn).Select(x => x.Key))
         {
-            pairs.Add(new CurrencyPair(SwissFranc, currency));
-            pairs.Add(new CurrencyPair(currency, SwissFranc));
+            pairs.Add(this.currencyPairFactory.Create(SwissFranc, currency));
+            pairs.Add(this.currencyPairFactory.Create(currency, SwissFranc));
         }
 
         return pairs;
@@ -111,7 +114,7 @@ public class SwissNationalBank : ISwissNationalBank
                     StringComparison.Ordinal));
 
                 this.foreignRates[currency] = new Tuple<DateTimeOffset, decimal>(date, rate);
-                result.Add(new ExchangeRate(new CurrencyPair(currency, SwissFranc), date, rate));
+                result.Add(new ExchangeRate(this.currencyPairFactory.Create(currency, SwissFranc), date, rate));
             }
         }
 

--- a/TIKSN.Framework.Core/Finance/ForeignExchange/ExchangeRateServiceBase.cs
+++ b/TIKSN.Framework.Core/Finance/ForeignExchange/ExchangeRateServiceBase.cs
@@ -11,6 +11,8 @@ namespace TIKSN.Finance.ForeignExchange;
 
 public abstract partial class ExchangeRateServiceBase : IExchangeRateService
 {
+    private readonly ICurrencyPairFactory currencyPairFactory;
+
     private readonly Dictionary<Guid,
         (Either<IExchangeRateProvider, IExchangeRatesProvider> RateProvider,
         string LongNameKey, string ShortNameKey,
@@ -20,10 +22,12 @@ public abstract partial class ExchangeRateServiceBase : IExchangeRateService
 
     protected ExchangeRateServiceBase(
         ILogger<ExchangeRateServiceBase> logger,
+        ICurrencyPairFactory currencyPairFactory,
         IRegionFactory regionFactory,
         IUnitOfWorkFactory unitOfWorkFactory)
     {
         this.Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.currencyPairFactory = currencyPairFactory ?? throw new ArgumentNullException(nameof(currencyPairFactory));
         this.RegionFactory = regionFactory ?? throw new ArgumentNullException(nameof(regionFactory));
 
         this.providers = [];
@@ -43,7 +47,7 @@ public abstract partial class ExchangeRateServiceBase : IExchangeRateService
         ArgumentNullException.ThrowIfNull(baseMoney);
         ArgumentNullException.ThrowIfNull(counterCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(
             pair, asOn, cancellationToken).ConfigureAwait(false);
@@ -62,7 +66,7 @@ public abstract partial class ExchangeRateServiceBase : IExchangeRateService
         ArgumentNullException.ThrowIfNull(counterCurrency);
         ArgumentNullException.ThrowIfNull(intermediaryCurrency);
 
-        var pair = new CurrencyPair(baseMoney.Currency, counterCurrency);
+        var pair = this.currencyPairFactory.Create(baseMoney.Currency, counterCurrency);
 
         var rate = await this.GetExchangeRateAsync(
             pair, asOn, intermediaryCurrency, cancellationToken).ConfigureAwait(false);
@@ -117,8 +121,8 @@ public abstract partial class ExchangeRateServiceBase : IExchangeRateService
         ArgumentNullException.ThrowIfNull(pair);
         ArgumentNullException.ThrowIfNull(intermediaryCurrency);
 
-        var syntheticCurrencyPair1 = new CurrencyPair(pair.BaseCurrency, intermediaryCurrency);
-        var syntheticCurrencyPair2 = new CurrencyPair(intermediaryCurrency, pair.CounterCurrency);
+        var syntheticCurrencyPair1 = this.currencyPairFactory.Create(pair.BaseCurrency, intermediaryCurrency);
+        var syntheticCurrencyPair2 = this.currencyPairFactory.Create(intermediaryCurrency, pair.CounterCurrency);
         var rate1 = await this.GetExchangeRateAsync(syntheticCurrencyPair1, asOn, cancellationToken)
             .ConfigureAwait(false);
         var rate2 = await this.GetExchangeRateAsync(syntheticCurrencyPair2, asOn, cancellationToken)

--- a/TIKSN.Framework.Core/Finance/ICurrencyPairFactory.cs
+++ b/TIKSN.Framework.Core/Finance/ICurrencyPairFactory.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using TIKSN.Globalization;
+
+namespace TIKSN.Finance;
+
+public interface ICurrencyPairFactory
+{
+    public CurrencyPair Create(CurrencyInfo baseCurrency, CurrencyInfo counterCurrency);
+
+    public CurrencyPair Create(string baseIsoCurrencySymbol, string counterIsoCurrencySymbol);
+
+    public CurrencyPair Create(RegionInfo baseRegion, RegionInfo counterRegion);
+
+    public CurrencyPair Create(CountryInfo baseCountry, CountryInfo counterCountry);
+
+    public CurrencyPair Reverse(CurrencyPair pair);
+
+    public CurrencyPair Reverse(CurrencyInfo baseCurrency, CurrencyInfo counterCurrency);
+
+    public CurrencyPair Reverse(string baseIsoCurrencySymbol, string counterIsoCurrencySymbol);
+
+    public CurrencyPair Reverse(RegionInfo baseRegion, RegionInfo counterRegion);
+
+    public CurrencyPair Reverse(CountryInfo baseCountry, CountryInfo counterCountry);
+
+    public bool TryCreate(
+        CurrencyInfo baseCurrency,
+        CurrencyInfo counterCurrency,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryCreate(
+        string baseIsoCurrencySymbol,
+        string counterIsoCurrencySymbol,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryCreate(
+        RegionInfo baseRegion,
+        RegionInfo counterRegion,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryCreate(
+        CountryInfo baseCountry,
+        CountryInfo counterCountry,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryReverse(CurrencyPair pair, [NotNullWhen(true)] out CurrencyPair? pairReversed);
+
+    public bool TryReverse(
+        CurrencyInfo baseCurrency,
+        CurrencyInfo counterCurrency,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryReverse(
+        string baseIsoCurrencySymbol,
+        string counterIsoCurrencySymbol,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryReverse(
+        RegionInfo baseRegion,
+        RegionInfo counterRegion,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+
+    public bool TryReverse(
+        CountryInfo baseCountry,
+        CountryInfo counterCountry,
+        [NotNullWhen(true)] out CurrencyPair? pair);
+}

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfCanadaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfCanadaTests.cs
@@ -202,7 +202,7 @@ public class BankOfCanadaTests
 
         foreach (var pair in currencyPairs)
         {
-            var reversePair = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversePair = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             currencyPairs.ShouldContain(c => c == reversePair);
         }
@@ -262,7 +262,7 @@ public class BankOfCanadaTests
         var usd = new CurrencyInfo(us);
         var cad = new CurrencyInfo(ca);
 
-        var pair = new CurrencyPair(cad, usd);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(cad, usd);
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow().AddMinutes(1d),
@@ -279,7 +279,7 @@ public class BankOfCanadaTests
         var aoa = new CurrencyInfo(ao);
         var bwp = new CurrencyInfo(bw);
 
-        var pair = new CurrencyPair(bwp, aoa);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(bwp, aoa);
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfEnglandTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfEnglandTests.cs
@@ -116,9 +116,9 @@ public class BankOfEnglandTests
     [Fact]
     public async Task ConvertCurrency003()
     {
-        var pair = new CurrencyPair(
-            new CurrencyInfo(new RegionInfo("AM")),
-            new CurrencyInfo(new RegionInfo("BY")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(
+            new RegionInfo("AM"),
+            new RegionInfo("BY"));
 
         var before = new Money(pair.BaseCurrency, amount: 10m);
 
@@ -274,9 +274,9 @@ public class BankOfEnglandTests
     [Fact]
     public async Task GetExchangeRate003()
     {
-        var pair = new CurrencyPair(
-            new CurrencyInfo(new RegionInfo("AM")),
-            new CurrencyInfo(new RegionInfo("BY")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(
+            new RegionInfo("AM"),
+            new RegionInfo("BY"));
 
         _ = await
             new Func<Task>(async () =>

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/BankOfRussiaTests.cs
@@ -109,7 +109,7 @@ public class BankOfRussiaTests
 
         foreach (var pair in currencyPairs)
         {
-            var reversePair = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversePair = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             currencyPairs.ShouldContain(c => c == reversePair);
         }
@@ -332,7 +332,7 @@ public class BankOfRussiaTests
         var usd = new CurrencyInfo(us);
         var rub = new CurrencyInfo(ru);
 
-        var pair = new CurrencyPair(rub, usd);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(rub, usd);
 
         _ = await
             new Func<Task>(async () =>
@@ -350,7 +350,7 @@ public class BankOfRussiaTests
         var aoa = new CurrencyInfo(ao);
         var bwp = new CurrencyInfo(bw);
 
-        var pair = new CurrencyPair(bwp, aoa);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(bwp, aoa);
 
         _ = await
             new Func<Task>(async () =>

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CentralBankOfArmeniaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CentralBankOfArmeniaTests.cs
@@ -306,7 +306,7 @@ public class CentralBankOfArmeniaTests
 
         foreach (var pair in currencyPairs)
         {
-            var reverse = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reverse = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             currencyPairs.ShouldContain(c => c == reverse);
         }
@@ -337,7 +337,7 @@ public class CentralBankOfArmeniaTests
 
         foreach (var pair in currencyPairs)
         {
-            var reversePair = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversePair = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             Math.Round(
                     await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),
@@ -357,7 +357,7 @@ public class CentralBankOfArmeniaTests
         var dollar = new CurrencyInfo(unitedStates);
         var dram = new CurrencyInfo(armenia);
 
-        var dollarPerDram = new CurrencyPair(dollar, dram);
+        var dollarPerDram = CurrencyPairTestHelper.CurrencyPairFactory.Create(dollar, dram);
 
         _ = await
             new Func<Task>(async () =>
@@ -375,7 +375,7 @@ public class CentralBankOfArmeniaTests
         var dollar = new CurrencyInfo(unitedStates);
         var dram = new CurrencyInfo(armenia);
 
-        var dollarPerDram = new CurrencyPair(dollar, dram);
+        var dollarPerDram = CurrencyPairTestHelper.CurrencyPairFactory.Create(dollar, dram);
 
         _ = await
             new Func<Task>(async () =>
@@ -392,7 +392,7 @@ public class CentralBankOfArmeniaTests
         var dollar = new CurrencyInfo(unitedStates);
         var dram = new CurrencyInfo(armenia);
 
-        var dollarPerDram = new CurrencyPair(dollar, dram);
+        var dollarPerDram = CurrencyPairTestHelper.CurrencyPairFactory.Create(dollar, dram);
 
         _ = await
             new Func<Task>(async () =>
@@ -409,7 +409,7 @@ public class CentralBankOfArmeniaTests
         var lek = new CurrencyInfo(albania);
         var dram = new CurrencyInfo(armenia);
 
-        var lekPerDram = new CurrencyPair(lek, dram);
+        var lekPerDram = CurrencyPairTestHelper.CurrencyPairFactory.Create(lek, dram);
 
         _ = await
             new Func<Task>(async () =>
@@ -427,7 +427,7 @@ public class CentralBankOfArmeniaTests
         var lek = new CurrencyInfo(albania);
         var dram = new CurrencyInfo(armenia);
 
-        var dramPerLek = new CurrencyPair(dram, lek);
+        var dramPerLek = CurrencyPairTestHelper.CurrencyPairFactory.Create(dram, lek);
 
         _ = await
             new Func<Task>(async () =>

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CurrencyPairTestHelper.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CurrencyPairTestHelper.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using TIKSN.DependencyInjection;
+using TIKSN.Finance;
+
+namespace TIKSN.IntegrationTests.Finance.ForeignExchange.Bank;
+
+internal static class CurrencyPairTestHelper
+{
+    public static ICurrencyPairFactory CurrencyPairFactory { get; } = CreateCurrencyPairFactory();
+
+    private static ICurrencyPairFactory CreateCurrencyPairFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        return services.BuildServiceProvider().GetRequiredService<ICurrencyPairFactory>();
+    }
+}

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/EuropeanCentralBankTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/EuropeanCentralBankTests.cs
@@ -134,7 +134,7 @@ public class EuropeanCentralBankTests
 
         foreach (var pair in pairs)
         {
-            var reversedPair = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversedPair = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             pairs.ShouldContain(p => p == reversedPair);
         }
@@ -357,7 +357,7 @@ public class EuropeanCentralBankTests
         var amd = new CurrencyInfo(new RegionInfo("AM"));
         var all = new CurrencyInfo(new RegionInfo("AL"));
 
-        var pair = new CurrencyPair(amd, all);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(amd, all);
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/FederalReserveSystemTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/FederalReserveSystemTests.cs
@@ -126,7 +126,7 @@ public class FederalReserveSystemTests
 
         foreach (var pair in pairs)
         {
-            var reversed = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversed = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             pairs.ShouldContain(c => c == reversed);
         }
@@ -253,7 +253,7 @@ public class FederalReserveSystemTests
     [Fact]
     public async Task GetExchangeRate004()
     {
-        var pair = new CurrencyPair(new CurrencyInfo(new RegionInfo("AL")), new CurrencyInfo(new RegionInfo("AM")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(new RegionInfo("AL"), new RegionInfo("AM"));
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow().AddMinutes(1d),
@@ -264,7 +264,7 @@ public class FederalReserveSystemTests
     [Fact]
     public async Task GetExchangeRate005()
     {
-        var pair = new CurrencyPair(new CurrencyInfo(new RegionInfo("US")), new CurrencyInfo(new RegionInfo("CN")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(new RegionInfo("US"), new RegionInfo("CN"));
 
         var rate = await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),
             cancellationToken: TestContext.Current.CancellationToken);
@@ -275,7 +275,7 @@ public class FederalReserveSystemTests
     [Fact]
     public async Task GetExchangeRate006()
     {
-        var pair = new CurrencyPair(new CurrencyInfo(new RegionInfo("US")), new CurrencyInfo(new RegionInfo("SG")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(new RegionInfo("US"), new RegionInfo("SG"));
 
         var rate = await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),
             cancellationToken: TestContext.Current.CancellationToken);
@@ -286,7 +286,7 @@ public class FederalReserveSystemTests
     [Fact]
     public async Task GetExchangeRate007()
     {
-        var pair = new CurrencyPair(new CurrencyInfo(new RegionInfo("US")), new CurrencyInfo(new RegionInfo("DE")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(new RegionInfo("US"), new RegionInfo("DE"));
 
         var rate = await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),
             cancellationToken: TestContext.Current.CancellationToken);
@@ -297,7 +297,7 @@ public class FederalReserveSystemTests
     [Fact]
     public async Task GetExchangeRate008()
     {
-        var pair = new CurrencyPair(new CurrencyInfo(new RegionInfo("US")), new CurrencyInfo(new RegionInfo("GB")));
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(new RegionInfo("US"), new RegionInfo("GB"));
 
         var rate = await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),
             cancellationToken: TestContext.Current.CancellationToken);

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingaporeTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/MonetaryAuthorityOfSingaporeTests.cs
@@ -65,7 +65,7 @@ public class MonetaryAuthorityOfSingaporeTests
     {
         var theSGD = this.currencyFactory.Create("SGD");
         var theUSD = this.currencyFactory.Create("USD");
-        var pair = new CurrencyPair(theUSD, theSGD);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(theUSD, theSGD);
         var asOn = new DateTimeOffset(year: 2024, month: 12, day: 31, hour: 0, minute: 0, second: 0,
             offset: TimeSpan.FromHours(8));
 

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/ReserveBankOfAustraliaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/ReserveBankOfAustraliaTests.cs
@@ -195,7 +195,7 @@ public class ReserveBankOfAustraliaTests
 
         foreach (var pair in currencyPairs)
         {
-            var reversedPair = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversedPair = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             currencyPairs.ShouldContain(p => p == reversedPair);
         }
@@ -290,7 +290,7 @@ public class ReserveBankOfAustraliaTests
         var armenianDram = new CurrencyInfo(armenia);
         var belarusianRuble = new CurrencyInfo(belarus);
 
-        var pair = new CurrencyPair(armenianDram, belarusianRuble);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(armenianDram, belarusianRuble);
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/SwissNationalBankTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/SwissNationalBankTests.cs
@@ -152,7 +152,7 @@ public class SwissNationalBankTests
 
         foreach (var pair in pairs)
         {
-            var reversed = new CurrencyPair(pair.CounterCurrency, pair.BaseCurrency);
+            var reversed = CurrencyPairTestHelper.CurrencyPairFactory.Reverse(pair);
 
             pairs.ShouldContain(p => p == reversed);
         }
@@ -216,7 +216,7 @@ public class SwissNationalBankTests
         var aoa = new CurrencyInfo(ao);
         var bwp = new CurrencyInfo(bw);
 
-        var pair = new CurrencyPair(aoa, bwp);
+        var pair = CurrencyPairTestHelper.CurrencyPairFactory.Create(aoa, bwp);
 
         _ = await new Func<Task>(async () =>
                 await this.bank.GetExchangeRateAsync(pair, this.timeProvider.GetUtcNow(),

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/ExchangeRateService/TestExchangeRateService.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/ExchangeRateService/TestExchangeRateService.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TIKSN.Data;
+using TIKSN.Finance;
 using TIKSN.Finance.ForeignExchange;
 using TIKSN.Finance.ForeignExchange.Bank;
 using TIKSN.Globalization;
@@ -27,10 +28,11 @@ public sealed class TestExchangeRateService : ExchangeRateServiceBase
         IReserveBankOfAustralia reserveBankOfAustralia,
         ISwissNationalBank swissNationalBank,
         ILogger<TestExchangeRateService> logger,
+        ICurrencyPairFactory currencyPairFactory,
         IRegionFactory regionFactory,
         IUnitOfWorkFactory unitOfWorkFactory,
         IDatabaseInitializer databaseInitializer)
-        : base(logger, regionFactory, unitOfWorkFactory)
+        : base(logger, currencyPairFactory, regionFactory, unitOfWorkFactory)
     {
         this.AddBatchProvider(
             Guid.Parse("e3cabe08-7451-445b-aeec-d41824f11317"),


### PR DESCRIPTION
## Summary
- Added `ICurrencyPairFactory` and a cached `CurrencyPairFactory` with `Create`, `TryCreate`, `Reverse`, and `TryReverse` overloads for currencies, ISO codes, regions, and countries.
- Registered the factory in framework DI and updated core finance services and bank providers to use it instead of constructing pairs directly.
- Added focused unit tests and updated integration tests to cover the new factory behavior and reverse semantics.

## Testing
- `dotnet test TIKSN.Framework.Core.Tests\TIKSN.Framework.Core.Tests.csproj --no-restore` passed.
- Integration test project compiled successfully with the updated constructor graph.