### PR TITLE
Enable warnings as errors for Maui and solution builds

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -352,18 +352,21 @@ Task BuildMaui EstimateVersion, {
     $project = Resolve-Path -Path 'TIKSN.Framework.Maui/TIKSN.Framework.Maui.csproj'
     $nextVersion = $state.NextVersion
 
-    Exec { dotnet build $project /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder }
+    Exec { dotnet build $project /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
 
-    Exec { dotnet build $project --framework net10.0-ios /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyIosBuildArtifactsFolder }
-    Exec { dotnet build $project --framework net10.0-maccatalyst /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyMaccatalystBuildArtifactsFolder }
-    Exec { dotnet build $project --framework net10.0-android /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyAndroidBuildArtifactsFolder }
-    Exec { dotnet build $project --framework net10.0-windows10.0.19041.0 /v:m /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyWindowsBuildArtifactsFolder }
+    Exec { dotnet build $project --framework net10.0-ios /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyIosBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
+    Exec { dotnet build $project --framework net10.0-maccatalyst /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyMaccatalystBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
+    Exec { dotnet build $project --framework net10.0-android /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyAndroidBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
+    Exec { dotnet build $project --framework net10.0-windows10.0.19041.0 /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:OutDir=$anyWindowsBuildArtifactsFolder /p:TreatWarningsAsErrors=true }
 }
 
 # Synopsis: Build
 Task Build Format, DownloadCurrencyCodes, BuildLanguageLocalization, BuildRegionLocalization, BuildCore, BuildMaui, {
+    $state = Import-Clixml -Path ".\.trash\$Instance\state.clixml"
     $solution = Resolve-Path -Path 'TIKSN Framework.slnx'
-    Exec { dotnet build $solution }
+    $nextVersion = $state.NextVersion
+
+    Exec { dotnet build $solution /v:m -warnaserror /p:Configuration=Release /p:version=$nextVersion /p:TreatWarningsAsErrors=true }
 }
 
 # Synopsis: Test

--- a/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CentralBankOfArmeniaTests.cs
+++ b/TIKSN.Framework.IntegrationTests/Finance/ForeignExchange/Bank/CentralBankOfArmeniaTests.cs
@@ -122,13 +122,13 @@ public class CentralBankOfArmeniaTests
         var passed = false;
 
         await Task.Run(async () =>
-        {
-            var ci = new CultureInfo("ru-RU");
-            Thread.CurrentThread.CurrentCulture = ci;
-            Thread.CurrentThread.CurrentUICulture = ci;
+            {
+                var ci = new CultureInfo("ru-RU");
+                Thread.CurrentThread.CurrentCulture = ci;
+                Thread.CurrentThread.CurrentUICulture = ci;
 
-            _ = await this.bank.GetExchangeRatesAsync(this.timeProvider.GetUtcNow(),
-                cancellationToken: TestContext.Current.CancellationToken);
+                _ = await this.bank.GetExchangeRatesAsync(this.timeProvider.GetUtcNow(),
+                    cancellationToken: TestContext.Current.CancellationToken);
 
             passed = true;
         }, TestContext.Current.CancellationToken);

--- a/TIKSN.Framework.Maui/Platforms/Windows/Settings/WindowsRegistrySettingsService.cs
+++ b/TIKSN.Framework.Maui/Platforms/Windows/Settings/WindowsRegistrySettingsService.cs
@@ -102,7 +102,11 @@ public class WindowsRegistrySettingsService : ISettingsService
     private static T GetSetting<T>(
         RegistryKey subKey,
         string name,
-        T defaultValue) => (T)subKey.GetValue(name, defaultValue)!;
+        T defaultValue)
+    {
+        var value = subKey.GetValue(name, defaultValue);
+        return value is null ? defaultValue : (T)value;
+    }
 
     private static IReadOnlyCollection<string> ListNames(
         RegistryKey subKey,
@@ -124,7 +128,9 @@ public class WindowsRegistrySettingsService : ISettingsService
         string name,
         T value)
     {
-        subKey.SetValue(name, value ?? throw new ArgumentNullException(nameof(value)));
+        ArgumentNullException.ThrowIfNull(value);
+
+        subKey.SetValue(name, value);
 
         return value;
     }


### PR DESCRIPTION
## Summary
- Applied warnings-as-errors to all Maui build targets and the solution build in the build script.
- Fixed the Maui Windows nullability warnings that surfaced under the stricter build.
- Cleaned up test code so the full solution build passes with warnings treated as errors.

## Testing
- `dotnet build "TIKSN Framework.slnx" /v:m -warnaserror /p:Configuration=Release /p:version=0.0.0-local /p:TreatWarningsAsErrors=true`
- `pwsh -File .\test.ps1`