### PR TITLE
Add country-aware currency resolution APIs

### DIFF
--- a/TIKSN.Framework.Core.Tests/Finance/CurrencyPairFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Finance/CurrencyPairFactoryTests.cs
@@ -17,10 +17,10 @@ public class CurrencyPairFactoryTests
         var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
         var currencyPairFactory = serviceProvider.GetRequiredService<ICurrencyPairFactory>();
 
-        var pair = currencyPairFactory.Create(countryFactory.Create("US"), countryFactory.Create("GB"));
+        var pair = currencyPairFactory.Create(countryFactory.Create("CN"), countryFactory.Create("US"));
 
-        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("USD");
-        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("GBP");
+        pair.BaseCurrency.ISOCurrencySymbol.ShouldBe("CNY");
+        pair.CounterCurrency.ISOCurrencySymbol.ShouldBe("USD");
     }
 
     [Fact]

--- a/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
+++ b/TIKSN.Framework.Core.Tests/Globalization/CurrencyFactoryTests.cs
@@ -80,6 +80,74 @@ public class CurrencyFactoryTests
     }
 
     [Theory]
+    [InlineData("CN", new[]
+    {
+        "CNY",
+        "HKD",
+        "MOP"
+    })]
+    [InlineData("FR", new[]
+    {
+        "EUR",
+        "XPF"
+    })]
+    [InlineData("US", new[]
+    {
+        "USD"
+    })]
+    public void GivenCountry_WhenAllCurrencyInfoCreated_ThenDistinctRegionalCurrenciesShouldBeReturned(
+        string inputCountryName,
+        string[] outputIsoCurrencySymbols)
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        var country = countryFactory.Create(inputCountryName);
+
+        // Act
+
+        var currencyInfos = currencyFactory.CreateAll(country);
+
+        // Assert
+
+        System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(
+                currencyInfos,
+                x => x.ISOCurrencySymbol))
+            .ShouldBe(outputIsoCurrencySymbols);
+    }
+
+    [Theory]
+    [InlineData("CN", "CNY")]
+    [InlineData("FR", "EUR")]
+    [InlineData("US", "USD")]
+    public void GivenCountry_WhenCurrencyInfoCreated_ThenPrincipalRegionCurrencyShouldBeReturned(
+        string inputCountryName,
+        string outputIsoCurrencySymbol)
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var countryFactory = serviceProvider.GetRequiredService<ICountryFactory>();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        var country = countryFactory.Create(inputCountryName);
+
+        // Act
+
+        var currencyInfo = currencyFactory.Create(country);
+
+        // Assert
+
+        _ = currencyInfo.ShouldNotBeNull();
+        currencyInfo.ISOCurrencySymbol.ShouldBe(outputIsoCurrencySymbol);
+    }
+
+    [Theory]
     [InlineData("GGP", "GBP")]
     [InlineData("JEP", "GBP")]
     [InlineData("IMP", "GBP")]
@@ -144,6 +212,48 @@ public class CurrencyFactoryTests
         // Act
 
         var created = currencyFactory.TryCreate("ZZZ", out var currency);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        currency.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullCountry_WhenTryCreateAllCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        CountryInfo country = null;
+
+        // Act
+
+        var created = currencyFactory.TryCreateAll(country, out var currencies);
+
+        // Assert
+
+        created.ShouldBeFalse();
+        currencies.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNullCountry_WhenTryCreateCalled_ThenItShouldReturnFalse()
+    {
+        // Arrange
+
+        var services = new ServiceCollection();
+        _ = services.AddFrameworkCore();
+        var serviceProvider = services.BuildServiceProvider();
+        var currencyFactory = serviceProvider.GetRequiredService<ICurrencyFactory>();
+        CountryInfo country = null;
+
+        // Act
+
+        var created = currencyFactory.TryCreate(country, out var currency);
 
         // Assert
 

--- a/TIKSN.Framework.Core/Finance/CurrencyPairFactory.cs
+++ b/TIKSN.Framework.Core/Finance/CurrencyPairFactory.cs
@@ -50,7 +50,9 @@ public class CurrencyPairFactory : MemoryCacheDecoratorBase<CurrencyPair>, ICurr
         ArgumentNullException.ThrowIfNull(baseCountry);
         ArgumentNullException.ThrowIfNull(counterCountry);
 
-        return this.Create(baseCountry.PrincipalRegion, counterCountry.PrincipalRegion);
+        return this.Create(
+            this.currencyFactory.Create(baseCountry),
+            this.currencyFactory.Create(counterCountry));
     }
 
     public CurrencyPair Reverse(CurrencyPair pair)

--- a/TIKSN.Framework.Core/Globalization/CurrencyFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/CurrencyFactory.cs
@@ -69,11 +69,48 @@ public class CurrencyFactory : MemoryCacheDecoratorBase<CurrencyInfo>, ICurrency
             ?? throw new InvalidOperationException("Failed to create CurrencyInfo.");
     }
 
+    public CurrencyInfo Create(CountryInfo country)
+    {
+        ArgumentNullException.ThrowIfNull(country);
+
+        return this.Create(country.PrincipalRegion);
+    }
+
+    public IReadOnlyCollection<CurrencyInfo> CreateAll(CountryInfo country)
+    {
+        ArgumentNullException.ThrowIfNull(country);
+
+        return Array.AsReadOnly(country.Regions
+            .Select(this.Create)
+            .Distinct()
+            .OrderBy(x => x.ISOCurrencySymbol, StringComparer.Ordinal)
+            .ToArray());
+    }
+
     public bool TryCreate(string isoCurrencySymbol, [NotNullWhen(true)] out CurrencyInfo? currency)
     {
         try
         {
             currency = this.Create(isoCurrencySymbol);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            currency = null;
+            return false;
+        }
+        catch (CurrencyNotFoundException)
+        {
+            currency = null;
+            return false;
+        }
+    }
+
+    public bool TryCreate(CountryInfo country, [NotNullWhen(true)] out CurrencyInfo? currency)
+    {
+        try
+        {
+            currency = this.Create(country);
             return true;
         }
         catch (ArgumentException)
@@ -103,6 +140,27 @@ public class CurrencyFactory : MemoryCacheDecoratorBase<CurrencyInfo>, ICurrency
         catch (CurrencyNotFoundException)
         {
             currency = null;
+            return false;
+        }
+    }
+
+    public bool TryCreateAll(
+        CountryInfo country,
+        [NotNullWhen(true)] out IReadOnlyCollection<CurrencyInfo>? currencies)
+    {
+        try
+        {
+            currencies = this.CreateAll(country);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            currencies = null;
+            return false;
+        }
+        catch (CurrencyNotFoundException)
+        {
+            currencies = null;
             return false;
         }
     }

--- a/TIKSN.Framework.Core/Globalization/ICurrencyFactory.cs
+++ b/TIKSN.Framework.Core/Globalization/ICurrencyFactory.cs
@@ -10,7 +10,17 @@ public interface ICurrencyFactory
 
     public CurrencyInfo Create(RegionInfo region);
 
+    public CurrencyInfo Create(CountryInfo country);
+
+    public IReadOnlyCollection<CurrencyInfo> CreateAll(CountryInfo country);
+
     public bool TryCreate(string isoCurrencySymbol, [NotNullWhen(true)] out CurrencyInfo? currency);
 
     public bool TryCreate(RegionInfo region, [NotNullWhen(true)] out CurrencyInfo? currency);
+
+    public bool TryCreate(CountryInfo country, [NotNullWhen(true)] out CurrencyInfo? currency);
+
+    public bool TryCreateAll(
+        CountryInfo country,
+        [NotNullWhen(true)] out IReadOnlyCollection<CurrencyInfo>? currencies);
 }


### PR DESCRIPTION
## Summary
- Added `ICurrencyFactory` overloads for `CountryInfo` so callers can resolve a country’s principal currency or enumerate all distinct regional currencies.
- Kept existing string and region-based currency resolution unchanged.
- Updated `CurrencyPairFactory` to resolve country currencies through the new country overloads.

## Testing
- Added unit coverage for country principal currency resolution, distinct regional currency lists, null country `TryCreate` paths, and a China-based country pair case.
- Verified the full solution with `dotnet test ".\TIKSN Framework.slnx"`.