### PR TITLE
Switch test projects to Microsoft Testing Platform

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -374,12 +374,16 @@ Task Test UnitTest, IntegrationTest
 
 # Synopsis: Integration Test
 Task IntegrationTest Build, {
-    Exec { dotnet test '.\TIKSN.Framework.IntegrationTests\TIKSN.Framework.IntegrationTests.csproj' }
+    $project = Resolve-Path -Path './TIKSN.Framework.IntegrationTests/TIKSN.Framework.IntegrationTests.csproj'
+
+    Exec { dotnet test --project $project }
 }
 
 # Synopsis: Unit Test
 Task UnitTest Build, {
-    Exec { dotnet test '.\TIKSN.Framework.Core.Tests\TIKSN.Framework.Core.Tests.csproj' }
+    $project = Resolve-Path -Path './TIKSN.Framework.Core.Tests/TIKSN.Framework.Core.Tests.csproj'
+
+    Exec { dotnet test --project $project }
 }
 
 # Synopsis: Pack NuGet package

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
@@ -43,7 +42,6 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.70" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.70" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.6.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
@@ -72,6 +70,5 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Useful direct commands:
 
 ```powershell
 dotnet restore "TIKSN Framework.slnx"
-dotnet test TIKSN.Framework.Core.Tests/TIKSN.Framework.Core.Tests.csproj
-dotnet test TIKSN.Framework.IntegrationTests/TIKSN.Framework.IntegrationTests.csproj
+dotnet test --project ./TIKSN.Framework.Core.Tests/TIKSN.Framework.Core.Tests.csproj
+dotnet test --project ./TIKSN.Framework.IntegrationTests/TIKSN.Framework.IntegrationTests.csproj
 ```
 
 Integration tests use Testcontainers to start required services such as MongoDB and RavenDB automatically. Ensure Docker is running before executing the integration test project.

--- a/TIKSN.Framework.Core.Tests/TIKSN.Framework.Core.Tests.csproj
+++ b/TIKSN.Framework.Core.Tests/TIKSN.Framework.Core.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <LangVersion>latest</LangVersion>
     <Company>TIKSN Development</Company>
     <Product>TIKSN Framework Tests</Product>
@@ -16,7 +18,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReactiveUI" />
@@ -29,9 +30,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3.assert" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TIKSN.Framework.Core\TIKSN.Framework.Core.csproj" />

--- a/TIKSN.Framework.IntegrationTests/TIKSN.Framework.IntegrationTests.csproj
+++ b/TIKSN.Framework.IntegrationTests/TIKSN.Framework.IntegrationTests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <UserSecretsId>TIKSN-Framework-tests-bee60aa7-e44d-4baf-9587-a0a3d5800585</UserSecretsId>
     <RootNamespace>TIKSN.IntegrationTests</RootNamespace>
   </PropertyGroup>
@@ -11,7 +13,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Shouldly" />
@@ -21,14 +22,6 @@
     <PackageReference Include="xunit.analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,8 @@
   "sdk": {
     "version": "10.0.100",
     "rollForward": "latestMajor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
## Summary
- Move the .NET 10 test projects to Microsoft Testing Platform with xUnit v3.
- Remove VSTest-specific test packages and central package entries that are no longer needed.
- Update the build script and README test commands to use `dotnet test --project`.

## Testing
- Restored the solution successfully.
- Ran both test projects directly under Microsoft Testing Platform; unit tests and integration tests passed.
- Not run (not requested): full CI workflow validation.