### PR TITLE
Fix dev-only dependencies showing up in NuGet package (#2374)

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -449,6 +449,18 @@ Task Pack Build, Test, {
         $project = [xml](Get-Content -Path $projectMapEntry.ProjectFile -Raw)
 
         foreach ($packageReference in $project.SelectNodes('//PackageReference')) {
+            $isPrivate = $false
+            if ($packageReference.HasAttribute('PrivateAssets') -and $packageReference.GetAttribute('PrivateAssets') -match '(?i)all') {
+                $isPrivate = $true
+            }
+            $privateAssetsNode = $packageReference.SelectSingleNode('*[local-name()=''PrivateAssets'']')
+            if ($null -ne $privateAssetsNode -and $privateAssetsNode.InnerText -match '(?i)all') {
+                $isPrivate = $true
+            }
+            if ($isPrivate) {
+                continue
+            }
+
             $packageId = $packageReference.Include
             $packageVersion = $centralPackages[$packageId]
 

--- a/TIKSN.Framework.Core/TIKSN.Framework.Core.csproj
+++ b/TIKSN.Framework.Core/TIKSN.Framework.Core.csproj
@@ -75,7 +75,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/TIKSN.Framework.Maui/TIKSN.Framework.Maui.csproj
+++ b/TIKSN.Framework.Maui/TIKSN.Framework.Maui.csproj
@@ -32,7 +32,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
+++ b/TIKSN.LanguageLocalization/TIKSN.LanguageLocalization.csproj
@@ -25,7 +25,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
+++ b/TIKSN.RegionLocalization/TIKSN.RegionLocalization.csproj
@@ -25,7 +25,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Closes #2374. This PR modifies the build script to correctly honor the \PrivateAssets\ attribute, preventing development dependencies like \Microsoft.SourceLink.GitHub\ and various Analyzers from propagating into the generated \.nuspec\ and being listed on nuget.org.